### PR TITLE
ci: remove unzip artifacts from workflow

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -175,15 +175,6 @@ jobs:
       with:
         path: artifacts/
 
-    - name: Unzip artifacts
-      shell: bash
-      run: |
-        for artifact in $(ls "artifacts/*.zip"); do
-          unzip "artifacts/${artifact}" -d .out
-          mv .out/* "artifacts/$(basename -s ".zip" "${artifact}")"
-        done
-        rm artifacts/*.zip
-
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION



<!-- 
Link the related issue :
#42
-->
#__ 

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->
The workflow try to unzip all artifacts downloaded but it seams `download-artifact` action already unzip it.

## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
