### PR TITLE
ci: fix missing GITHUB_TOKEN secret on sementic-release

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -187,6 +187,8 @@ jobs:
     - id: release
       name: Release
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx semantic-release@18
 
     - name: Install cargo-edit


### PR DESCRIPTION
<!-- 
Link the related issue :
#42
-->
#__ 

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->
The release didn't work because sementic-release didn't know the GH_TOKEN

## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
