### PR TITLE
fix: Ignore bin dependencies in lib

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -158,7 +158,7 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --release -F bin --target ${{ matrix.target }}
+        args: --release -F cli --target ${{ matrix.target }}
 
     - name: Zip
       if: ${{ matrix.os == 'windows' }}

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -158,7 +158,7 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --release --target ${{ matrix.target }}
+        args: --release -F bin --target ${{ matrix.target }}
 
     - name: Zip
       if: ${{ matrix.os == 'windows' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ include = [
 [lib]
 name = "dofigen_lib"
 path = "src/lib.rs"
+required-features = []
 
 [[bin]]
 name = "dofigen"
 path = "src/bin/main.rs"
+required-features = ["bin"]
 
 [features]
-default = ["bin"]
 bin = ["clap"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ path = "src/lib.rs"
 [[bin]]
 name = "dofigen"
 path = "src/bin/main.rs"
-required-features = ["bin"]
+required-features = ["cli"]
 
 [features]
-bin = ["clap"]
+cli = ["clap"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 [lib]
 name = "dofigen_lib"
 path = "src/lib.rs"
-required-features = []
 
 [[bin]]
 name = "dofigen"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ First install Cargo, the Rust package manager: https://doc.rust-lang.org/cargo/g
 Then use the next command to install dofigen:
 
 ```bash
-cargo install dofigen
+cargo install dofigen -F bin
 ```
 
 #### Download the binary

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ First install Cargo, the Rust package manager: https://doc.rust-lang.org/cargo/g
 Then use the following command to install dofigen:
 
 ```bash
-cargo install dofigen -F bin
+cargo install dofigen -F cli
 ```
 
 #### Download the binary

--- a/dofigen.yml
+++ b/dofigen.yml
@@ -6,7 +6,7 @@ builders:
   - "."
   script:
   # Build with musl to work with scratch
-  - cargo build --release -F bin --target=x86_64-unknown-linux-musl
+  - cargo build --release -F cli --target=x86_64-unknown-linux-musl
   # copy the generated binary outside of the target directory. If not the other stages won't be able to find it since it's in a cache volume
   - mv target/x86_64-unknown-linux-musl/release/dofigen ../
   caches:

--- a/dofigen.yml
+++ b/dofigen.yml
@@ -6,7 +6,7 @@ builders:
   - "."
   script:
   # Build with musl to work with scratch
-  - cargo build --release --target=x86_64-unknown-linux-musl
+  - cargo build --release -F bin --target=x86_64-unknown-linux-musl
   # copy the generated binary outside of the target directory. If not the other stages won't be able to find it since it's in a cache volume
   - mv target/x86_64-unknown-linux-musl/release/dofigen ../
   caches:


### PR DESCRIPTION
## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
Do not load the bin dependencies in the lib crate.

## Technical highlight/advice

The `cargo install` must specify the bin feature: `cargo install dofigen -F cli`
