### PR TITLE
feat: Add field aliases to overlap Dockerfile keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The image is the main element. It defines the runtime stage of the Dockerfile:
 | Field            | Type             | Description                   |
 |------------------|------------------|-------------------------------|
 | `image`          | String?          | The `FROM` Docker image       |
+| `from`           | String?          | `image` alias                 |
 | `user`           | String?          | The runtime user (default `1000`) |
 | `workdir`        | String?          | The runtime work directory    |
 | `envs`           | Map<String, String>? | The runtime environment variables |
@@ -152,6 +153,7 @@ The image is the main element. It defines the runtime stage of the Dockerfile:
 | `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
 | `root`           | [Root](#root)?   | Actions made using the `root` user |
 | `script`         | String[]?        | Script commands to execute    |
+| `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
 | `builders`       | [Builder](#builder)[]? | Build stages executed before the runtime stage and not in the final Docker image. Mostly to generate artifacts |
 | `ports`          | int[]?           | The list of exposed ports of the Docker image |
@@ -168,6 +170,7 @@ The builders are stages executed before the runtime stage and not in the final D
 |------------------|------------------|-------------------------------|
 | `name`           | String?          | The builder name. If not defined, a name is defined with the given pattern: `builder-<position in the builders list starting at 0>` |
 | `image`          | String?          | The `FROM` Docker image of the builder |
+| `from`           | String?          | `image` alias                 |
 | `user`           | String?          | The builder user              |
 | `workdir`        | String?          | The builder work directory    |
 | `envs`           | Map<String, String>? | The builder environment variables |
@@ -175,6 +178,7 @@ The builders are stages executed before the runtime stage and not in the final D
 | `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
 | `root`           | [Root](#root)?   | Actions made using the `root` user |
 | `script`         | String[]?        | Script commands to execute    |
+| `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
 
 #### Artifact
@@ -194,6 +198,7 @@ Actions made using the `root` user :
 | Field            | Type             | Description                   |
 |------------------|------------------|-------------------------------|
 | `script`         | String[]?        | Script commands to execute    |
+| `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
 
 #### Healthcheck

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The Docker image's healthcheck definition. It defines when the container is not 
 | `cmd`            | String           | The command executed to check the container health |
 | `interval`       | String?          | The command execution interval (default `30s`) |
 | `timeout`        | String?          | The command execution timeout (default `30s`) |
-| `start`          | String?          | The duration before starting the commmand execution at container start (default `0s`) |
+| `start`          | String?          | The duration before starting the command execution at container start (default `0s`) |
 | `retries`        | int?             | The number of retries before defining the container as unhealthy (default `3`) |
 
 <p align="right">(<a href="#top">back to top</a>)</p>

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Image {
     // Common part
+    #[serde(alias = "from")]
     pub image: String,
     pub user: Option<String>,
     pub workdir: Option<String>,
@@ -12,6 +13,7 @@ pub struct Image {
     pub artifacts: Option<Vec<Artifact>>,
     pub adds: Option<Vec<String>>,
     pub root: Option<Root>,
+    #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
     pub caches: Option<Vec<String>>,
     // Specific part
@@ -27,6 +29,7 @@ pub struct Image {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Builder {
     // Common part
+    #[serde(alias = "from")]
     pub image: String,
     pub user: Option<String>,
     pub workdir: Option<String>,
@@ -34,6 +37,7 @@ pub struct Builder {
     pub artifacts: Option<Vec<Artifact>>,
     pub adds: Option<Vec<String>>,
     pub root: Option<Root>,
+    #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
     pub caches: Option<Vec<String>>,
     // Specific part
@@ -49,6 +53,7 @@ pub struct Artifact {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Root {
+    #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
     pub caches: Option<Vec<String>>,
 }


### PR DESCRIPTION
Closes #15  

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
Add aliases to fileds:
- `from`: alias to `image` field
- `run`: alias to `script` field
