### PR TITLE
ci: Binary in root dir of tar archives

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -167,7 +167,7 @@ jobs:
     - name: Zip
       if: ${{ matrix.os != 'windows' }}
       shell: bash
-      run: tar -czf "dofigen-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" "target/${{ matrix.target }}/release/dofigen${{ matrix.file_extension }}"
+      run: tar -C "target/${{ matrix.target }}/release" -czf "dofigen-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" "dofigen${{ matrix.file_extension }}"
 
     - name: Upload
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Closes #44

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
Make binary artifacts be at the root directory of the tar archives.