### PR TITLE
fix: No error on unknown fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,22 @@ The image is the main element. It defines the runtime stage of the Dockerfile:
 | `user`           | String?          | The runtime user (default `1000`) |
 | `workdir`        | String?          | The runtime work directory    |
 | `envs`           | Map<String, String>? | The runtime environment variables |
+| `env`            | Map<String, String>? | `envs` alias              |
 | `artifacts`      | [Artifact](#artifact)[]? | Defines artifacts to copy from builders |
 | `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
+| `add`            | String[]?        | `adds` alias                  |
 | `root`           | [Root](#root)?   | Actions made using the `root` user |
 | `script`         | String[]?        | Script commands to execute    |
 | `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
+| `cache`          | String[]?        | `caches` alias                |
 | `builders`       | [Builder](#builder)[]? | Build stages executed before the runtime stage and not in the final Docker image. Mostly to generate artifacts |
 | `ports`          | int[]?           | The list of exposed ports of the Docker image |
 | `healthcheck`    | [Healthcheck](#healthcheck)? | The Docker image healthcheck definition. |
 | `entrypoint`     | String[]?        | The Docker image `ENTRYPOINT` parts |
 | `cmd`            | String[]?        | The Docker image `CMD` parts  |
 | `ignores`        | String[]?        | Paths to generate the `.dockerignore` file |
+| `ignore`         | String[]?        | `ignores` alias               |
 
 #### Builder
 
@@ -175,12 +179,15 @@ The builders are stages executed before the runtime stage and not in the final D
 | `user`           | String?          | The builder user              |
 | `workdir`        | String?          | The builder work directory    |
 | `envs`           | Map<String, String>? | The builder environment variables |
+| `env`            | Map<String, String>? | `envs` alias              |
 | `artifacts`      | [Artifact](#artifact)[]? | Defines artifacts to copy from previous builders |
 | `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
+| `add`            | String[]?        | `adds` alias                  |
 | `root`           | [Root](#root)?   | Actions made using the `root` user |
 | `script`         | String[]?        | Script commands to execute    |
 | `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
+| `cache`          | String[]?        | `caches` alias                |
 
 #### Artifact
 
@@ -191,6 +198,7 @@ Artifacts are element copied from a previous build to the current stage :
 | `builder`        | String           | The builder name from which the artifact will be copied |
 | `source`         | String           | The source of the artifact in the given builder |
 | `destination`    | String           | The destination path in the current stage |
+| `target`         | String           | `destination` alias           |
 
 #### Root
 
@@ -201,6 +209,7 @@ Actions made using the `root` user :
 | `script`         | String[]?        | Script commands to execute    |
 | `run`            | String?          | `script` alias                |
 | `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
+| `cache`          | String[]?        | `caches` alias                |
 
 #### Healthcheck
 

--- a/README.md
+++ b/README.md
@@ -143,85 +143,71 @@ ignores:
 
 The image is the main element. It defines the runtime stage of the Dockerfile:
 
-| Field            | Type             | Description                   |
-|------------------|------------------|-------------------------------|
-| `image`          | String?          | The `FROM` Docker image       |
-| `from`           | String?          | `image` alias                 |
-| `user`           | String?          | The runtime user (default `1000`) |
-| `workdir`        | String?          | The runtime work directory    |
-| `envs`           | Map<String, String>? | The runtime environment variables |
-| `env`            | Map<String, String>? | `envs` alias              |
-| `artifacts`      | [Artifact](#artifact)[]? | Defines artifacts to copy from builders |
-| `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
-| `add`            | String[]?        | `adds` alias                  |
-| `root`           | [Root](#root)?   | Actions made using the `root` user |
-| `script`         | String[]?        | Script commands to execute    |
-| `run`            | String?          | `script` alias                |
-| `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
-| `cache`          | String[]?        | `caches` alias                |
-| `builders`       | [Builder](#builder)[]? | Build stages executed before the runtime stage and not in the final Docker image. Mostly to generate artifacts |
-| `ports`          | int[]?           | The list of exposed ports of the Docker image |
-| `healthcheck`    | [Healthcheck](#healthcheck)? | The Docker image healthcheck definition. |
-| `entrypoint`     | String[]?        | The Docker image `ENTRYPOINT` parts |
-| `cmd`            | String[]?        | The Docker image `CMD` parts  |
-| `ignores`        | String[]?        | Paths to generate the `.dockerignore` file |
-| `ignore`         | String[]?        | `ignores` alias               |
+| Field            | Alias            | Type             | Description                   |
+|------------------|------------------|------------------|-------------------------------|
+| `image`          | `from`           | String?          | The `FROM` Docker image       |
+| `user`           |                  | String?          | The runtime user (default `1000`) |
+| `workdir`        |                  | String?          | The runtime work directory    |
+| `envs`           | `env`            | Map<String, String>? | The runtime environment variables |
+| `artifacts`      |                  | [Artifact](#artifact)[]? | Defines artifacts to copy from builders |
+| `adds`           | `add`            | String[]?        | Paths of elements to add at build time to the workdir |
+| `root`           |                  | [Root](#root)?   | Actions made using the `root` user |
+| `script`         | `run`            | String[]?        | Script commands to execute    |
+| `caches`         | `cache`          | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
+| `builders`       |                  | [Builder](#builder)[]? | Build stages executed before the runtime stage and not in the final Docker image. Mostly to generate artifacts |
+| `ports`          |                  | int[]?           | The list of exposed ports of the Docker image |
+| `healthcheck`    |                  | [Healthcheck](#healthcheck)? | The Docker image healthcheck definition. |
+| `entrypoint`     |                  | String[]?        | The Docker image `ENTRYPOINT` parts |
+| `cmd`            |                  | String[]?        | The Docker image `CMD` parts  |
+| `ignores`        | `ignore`         | String[]?        | Paths to generate the `.dockerignore` file |
 
 #### Builder
 
 The builders are stages executed before the runtime stage and not in the final Docker image. Mostly to generate artifacts :
 
-| Field            | Type             | Description                   |
-|------------------|------------------|-------------------------------|
-| `name`           | String?          | The builder name. If not defined, a name is defined with the given pattern: `builder-<position in the builders list starting at 0>` |
-| `image`          | String?          | The `FROM` Docker image of the builder |
-| `from`           | String?          | `image` alias                 |
-| `user`           | String?          | The builder user              |
-| `workdir`        | String?          | The builder work directory    |
-| `envs`           | Map<String, String>? | The builder environment variables |
-| `env`            | Map<String, String>? | `envs` alias              |
-| `artifacts`      | [Artifact](#artifact)[]? | Defines artifacts to copy from previous builders |
-| `adds`           | String[]?        | Paths of elements to add at build time to the workdir |
-| `add`            | String[]?        | `adds` alias                  |
-| `root`           | [Root](#root)?   | Actions made using the `root` user |
-| `script`         | String[]?        | Script commands to execute    |
-| `run`            | String?          | `script` alias                |
-| `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
-| `cache`          | String[]?        | `caches` alias                |
+| Field            | Alias            | Type             | Description                   |
+|------------------|------------------|------------------|-------------------------------|
+| `name`           |                  | String?          | The builder name. If not defined, a name is defined with the given pattern: `builder-<position in the builders list starting at 0>` |
+| `image`          | `from`           | String?          | The `FROM` Docker image of the builder |
+| `user`           |                  | String?          | The builder user              |
+| `workdir`        |                  | String?          | The builder work directory    |
+| `envs`           | `env`            | Map<String, String>? | The builder environment variables |
+| `artifacts`      |                  | [Artifact](#artifact)[]? | Defines artifacts to copy from previous builders |
+| `adds`           | `add`            | String[]?        | Paths of elements to add at build time to the workdir |
+| `root`           |                  | [Root](#root)?   | Actions made using the `root` user |
+| `script`         | `run`            | String[]?        | Script commands to execute    |
+| `caches`         | `cache`          | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
 
 #### Artifact
 
 Artifacts are element copied from a previous build to the current stage :
 
-| Field            | Type             | Description                   |
-|------------------|------------------|-------------------------------|
-| `builder`        | String           | The builder name from which the artifact will be copied |
-| `source`         | String           | The source of the artifact in the given builder |
-| `destination`    | String           | The destination path in the current stage |
-| `target`         | String           | `destination` alias           |
+| Field            | Alias            | Type             | Description                   |
+|------------------|------------------|------------------|-------------------------------|
+| `builder`        |                  | String           | The builder name from which the artifact will be copied |
+| `source`         |                  | String           | The source of the artifact in the given builder |
+| `destination`    | `target`         | String           | The destination path in the current stage |
 
 #### Root
 
 Actions made using the `root` user :
 
-| Field            | Type             | Description                   |
-|------------------|------------------|-------------------------------|
-| `script`         | String[]?        | Script commands to execute    |
-| `run`            | String?          | `script` alias                |
-| `caches`         | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
-| `cache`          | String[]?        | `caches` alias                |
+| Field            | Alias            | Type             | Description                   |
+|------------------|------------------|------------------|-------------------------------|
+| `script`         | `run`            | String[]?        | Script commands to execute    |
+| `caches`         | `cache`          | String[]?        | Paths in the image stage to cache during the `script` execution. Be careful when using caches because the cached directory is not present after the script execution |
 
 #### Healthcheck
 
 The Docker image's healthcheck definition. It defines when the container is not healthy :
 
-| Field            | Type             | Description                   |
-|------------------|------------------|-------------------------------|
-| `cmd`            | String           | The command executed to check the container health |
-| `interval`       | String?          | The command execution interval (default `30s`) |
-| `timeout`        | String?          | The command execution timeout (default `30s`) |
-| `start`          | String?          | The duration before starting the command execution at container start (default `0s`) |
-| `retries`        | int?             | The number of retries before defining the container as unhealthy (default `3`) |
+| Field            | Alias            | Type             | Description                   |
+|------------------|------------------|------------------|-------------------------------|
+| `cmd`            |                  | String           | The command executed to check the container health |
+| `interval`       |                  | String?          | The command execution interval (default `30s`) |
+| `timeout`        |                  | String?          | The command execution timeout (default `30s`) |
+| `start`          |                  | String?          | The duration before starting the command execution at container start (default `0s`) |
+| `retries`        |                  | int?             | The number of retries before defining the container as unhealthy (default `3`) |
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,41 +671,48 @@ test: Fake value
 "#;
         let result = from(yaml.to_string());
         assert!(result.is_err(), "The parsing must fail since 'test' is not a valid field");
+
+        // Check the error message
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Error while deserializing the YAML document: unknown field `test`, expected one of `from`, `image`, `user`, `workdir`, `env`, `envs`, `artifacts`, `add`, `adds`, `root`, `run`, `script`, `cache`, `caches`, `builders`, `ignore`, `ignores`, `entrypoint`, `cmd`, `ports`, `healthcheck` at line 3 column 1"
+        );
     }
     
     #[test]
-    fn manage_singular_aliases() {
+    fn manage_singular_aliases() -> Result<()>{
         let yaml = r#"
-        image: scratch
-        builders:
-        - name: builder
-          image: ekidd/rust-musl-builder
-          user: rust
-          add: 
-          - "."
-          script:
-          - cargo build --release
-          cache:
-          - /usr/local/cargo/registry
-        - name: watchdog
-          image: ghcr.io/openfaas/of-watchdog:0.9.6
-        env:
-          fprocess: /app
-        artifacts:
-        - builder: builder
-          source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
-          destination: /app
-        - builder: builder
-          source: /fwatchdog
-          target: /fwatchdog
-        ports:
-        - 8080
-        ignore:
-        - target
-        - test
-        "#;
+image: scratch
+builders:
+- name: builder
+  image: ekidd/rust-musl-builder
+  user: rust
+  add: 
+  - "."
+  script:
+  - cargo build --release
+  cache:
+  - /usr/local/cargo/registry
+- name: watchdog
+  image: ghcr.io/openfaas/of-watchdog:0.9.6
+env:
+  fprocess: /app
+artifacts:
+- builder: builder
+  source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
+  destination: /app
+- builder: builder
+  source: /fwatchdog
+  target: /fwatchdog
+ports:
+- 8080
+ignore:
+- target
+- test
+"#;
 
-        let result = from(yaml.to_string());
-        assert!(result.is_ok(), "The parsing should be ok with the aliases");
+        from(yaml.to_string())?;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,10 @@ image: scratch
 from: alpine
 "#;
         let result = from(yaml.to_string());
-        assert!(result.is_err(), "The parsing must fail since from and image are not compatible");
+        assert!(
+            result.is_err(),
+            "The parsing must fail since from and image are not compatible"
+        );
     }
 
     #[test]
@@ -670,7 +673,10 @@ from: alpine
 test: Fake value
 "#;
         let result = from(yaml.to_string());
-        assert!(result.is_err(), "The parsing must fail since 'test' is not a valid field");
+        assert!(
+            result.is_err(),
+            "The parsing must fail since 'test' is not a valid field"
+        );
 
         // Check the error message
         let error = result.unwrap_err();
@@ -679,9 +685,9 @@ test: Fake value
             "Error while deserializing the YAML document: unknown field `test`, expected one of `from`, `image`, `user`, `workdir`, `env`, `envs`, `artifacts`, `add`, `adds`, `root`, `run`, `script`, `cache`, `caches`, `builders`, `ignore`, `ignores`, `entrypoint`, `cmd`, `ports`, `healthcheck` at line 3 column 1"
         );
     }
-    
+
     #[test]
-    fn manage_singular_aliases() -> Result<()>{
+    fn manage_singular_aliases() -> Result<()> {
         let yaml = r#"
 image: scratch
 builders:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ pub fn from_file_path(path: &std::path::PathBuf) -> Result<Image> {
 /// let dockerfile: String = generate_dockerfile(&image);
 /// assert_eq!(
 ///     dockerfile,
-///     "# syntax=docker/dockerfile:1.4\n\n# runtime\nFROM scratch as runtime\n"
+///     "# syntax=docker/dockerfile:1.4\n\n# runtime\nFROM scratch AS runtime\n"
 /// );
 /// ```
 pub fn generate_dockerfile(image: &Image) -> String {
@@ -553,7 +553,7 @@ mod tests {
           - "."
           script:
           - cargo build --release
-          cache:
+          caches:
           - /usr/local/cargo/registry
         - name: watchdog
           image: ghcr.io/openfaas/of-watchdog:0.9.6
@@ -585,17 +585,18 @@ mod tests {
             r#"# syntax=docker/dockerfile:1.4
 
 # builder
-FROM ekidd/rust-musl-builder as builder
+FROM ekidd/rust-musl-builder AS builder
 ADD --link . ./
 USER rust
 RUN \
+    --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/usr/local/cargo/registry\
     cargo build --release
 
 # watchdog
-FROM ghcr.io/openfaas/of-watchdog:0.9.6 as watchdog
+FROM ghcr.io/openfaas/of-watchdog:0.9.6 AS watchdog
 
 # runtime
-FROM scratch as runtime
+FROM scratch AS runtime
 ENV \
     fprocess="/app"
 COPY --link --chown=1000:1000 --from=builder "/home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust" "/app"
@@ -659,6 +660,52 @@ image: scratch
 from: alpine
 "#;
         let result = from(yaml.to_string());
-        assert!(result.is_err());
+        assert!(result.is_err(), "The parsing must fail since from and image are not compatible");
+    }
+
+    #[test]
+    fn fail_on_unknow_field() {
+        let yaml = r#"
+from: alpine
+test: Fake value
+"#;
+        let result = from(yaml.to_string());
+        assert!(result.is_err(), "The parsing must fail since 'test' is not a valid field");
+    }
+    
+    #[test]
+    fn manage_singular_aliases() {
+        let yaml = r#"
+        image: scratch
+        builders:
+        - name: builder
+          image: ekidd/rust-musl-builder
+          user: rust
+          add: 
+          - "."
+          script:
+          - cargo build --release
+          cache:
+          - /usr/local/cargo/registry
+        - name: watchdog
+          image: ghcr.io/openfaas/of-watchdog:0.9.6
+        env:
+          fprocess: /app
+        artifacts:
+        - builder: builder
+          source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
+          destination: /app
+        - builder: builder
+          source: /fwatchdog
+          target: /fwatchdog
+        ports:
+        - 8080
+        ignore:
+        - target
+        - test
+        "#;
+
+        let result = from(yaml.to_string());
+        assert!(result.is_ok(), "The parsing should be ok with the aliases");
     }
 }

--- a/src/stages.rs
+++ b/src/stages.rs
@@ -81,7 +81,7 @@ macro_rules! impl_Stage {
         $(impl Stage for $t {
             fn generate(&self, buffer: &mut String, previous_builders: &mut Vec<String>) -> Result<()> {
                 let name = self.name(previous_builders.len().try_into().unwrap());
-                buffer.push_str(format!("\n# {}\nFROM {} as {}\n", name, self.image, name).as_str());
+                buffer.push_str(format!("\n# {}\nFROM {} AS {}\n", name, self.image, name).as_str());
 
                 // Set env variables
                 if let Some(ref envs) = self.envs {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -3,21 +3,26 @@ use std::collections::HashMap;
 
 /** Represents the Dockerfile main stage */
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Image {
     // Common part
     #[serde(alias = "from")]
     pub image: String,
     pub user: Option<String>,
     pub workdir: Option<String>,
+    #[serde(alias = "env")]
     pub envs: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
+    #[serde(alias = "add")]
     pub adds: Option<Vec<String>>,
     pub root: Option<Root>,
     #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
+    #[serde(alias = "cache")]
     pub caches: Option<Vec<String>>,
     // Specific part
     pub builders: Option<Vec<Builder>>,
+    #[serde(alias = "ignore")]
     pub ignores: Option<Vec<String>>,
     pub entrypoint: Option<Vec<String>>,
     pub cmd: Option<Vec<String>>,
@@ -33,12 +38,15 @@ pub struct Builder {
     pub image: String,
     pub user: Option<String>,
     pub workdir: Option<String>,
+    #[serde(alias = "env")]
     pub envs: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
+    #[serde(alias = "add")]
     pub adds: Option<Vec<String>>,
     pub root: Option<Root>,
     #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
+    #[serde(alias = "cache")]
     pub caches: Option<Vec<String>>,
     // Specific part
     pub name: Option<String>,
@@ -48,6 +56,7 @@ pub struct Builder {
 pub struct Artifact {
     pub builder: String,
     pub source: String,
+    #[serde(alias = "target")]
     pub destination: String,
 }
 
@@ -55,6 +64,7 @@ pub struct Artifact {
 pub struct Root {
     #[serde(alias = "run")]
     pub script: Option<Vec<String>>,
+    #[serde(alias = "cache")]
     pub caches: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes #175
Closes #122

## Technical highlight/advice

The parse fails on unknown fields and some aliases have been added.

## How to test my changes

The next Dofigen file should work fine on this version but not on the previous ones:

```yaml
image: scratch
builders:
- name: builder
    image: ekidd/rust-musl-builder
    user: rust
    add: 
    - "."
    script:
    - cargo build --release
    cache:
    - /usr/local/cargo/registry
- name: watchdog
    image: ghcr.io/openfaas/of-watchdog:0.9.6
env:
    fprocess: /app
artifacts:
- builder: builder
    source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
    destination: /app
- builder: builder
    source: /fwatchdog
    target: /fwatchdog
ports:
- 8080
ignore:
- target
- test
```

And the next Dofigen file should fail:

```yaml
from: scratch
fake: value
```


## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [x] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


