### PR TITLE
feat: Manage context by inclusion instead of exclusion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD --link . ./
 RUN \
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/rust/.cargo\
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/rust/src/target\
-    cargo build --release --target=x86_64-unknown-linux-musl && \
+    cargo build --release -F cli --target=x86_64-unknown-linux-musl && \
     mv target/x86_64-unknown-linux-musl/release/dofigen ../
 
 # runtime

--- a/README.md
+++ b/README.md
@@ -132,11 +132,10 @@ entrypoint:
 - /bin/dofigen
 cmd:
 - --help
-ignores:
-- "**"
-- "!/dofigen"
-- "!/dofigen_lib"
-- "!/Cargo.*"
+context:
+- "/dofigen"
+- "/dofigen_lib"
+- "/Cargo.*"
 ```
 
 #### Image
@@ -161,7 +160,8 @@ The image is the main element. It defines the runtime stage of the Dockerfile:
 | `healthcheck`    | [Healthcheck](#healthcheck)? | The Docker image healthcheck definition. |
 | `entrypoint`     | String[]?        | The Docker image `ENTRYPOINT` parts |
 | `cmd`            | String[]?        | The Docker image `CMD` parts  |
-| `ignores`        | String[]?        | Paths to generate the `.dockerignore` file |
+| `context`        | String[]?        | Paths of the elements to include in the Docker build context. They are used to generate the `.dockerignore` file |
+| `ignores`        | String[]?        | Paths that will be added in the `.dockerignore` file |
 
 #### Builder
 

--- a/dofigen.yml
+++ b/dofigen.yml
@@ -24,7 +24,6 @@ entrypoint:
 - /bin/dofigen
 cmd:
 - --help
-ignores:
-- "**"
-- "!/src"
-- "!/Cargo.*"
+context:
+- "/src"
+- "/Cargo.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,25 @@ pub fn generate_dockerfile(image: &Image) -> String {
 ///
 /// # Examples
 ///
+/// ## Define the build context
+/// 
+/// ```
+/// use dofigen_lib::{generate_dockerignore, Image};
+///
+/// let image = Image {
+///     image: String::from("scratch"),
+///     context: Some(Vec::from([String::from("/src")])),
+///     ..Default::default()
+/// };
+/// let dockerfile: String = generate_dockerignore(&image);
+/// assert_eq!(
+///     dockerfile,
+///     "**\n!/src\n"
+/// );
+/// ```
+/// 
+/// ## Ignore a path
+/// 
 /// ```
 /// use dofigen_lib::{generate_dockerignore, Image};
 ///
@@ -527,13 +546,40 @@ pub fn generate_dockerfile(image: &Image) -> String {
 ///     "target\n"
 /// );
 /// ```
+/// 
+/// ## Define context ignoring a specific files
+/// 
+/// ```
+/// use dofigen_lib::{generate_dockerignore, Image};
+///
+/// let image = Image {
+///     image: String::from("scratch"),
+///     context: Some(Vec::from([String::from("/src")])),
+///     ignores: Some(Vec::from([String::from("/src/*.test.rs")])),
+///     ..Default::default()
+/// };
+/// let dockerfile: String = generate_dockerignore(&image);
+/// assert_eq!(
+///     dockerfile,
+///     "**\n!/src\n/src/*.test.rs\n"
+/// );
+/// ```
 pub fn generate_dockerignore(image: &Image) -> String {
-    let mut content = if let Some(ignore) = image.ignores() {
-        ignore.join("\n")
-    } else {
-        String::from("")
-    };
-    content.push_str("\n");
+    let mut content = String::new();
+    if let Some(context) = image.context.clone() {
+        content.push_str("**\n");
+        context.iter().for_each(|path| {
+            content.push_str("!");
+            content.push_str(path);
+            content.push_str("\n");
+        });
+    }
+    if let Some(ignore) = image.ignores.clone() {
+        ignore.iter().for_each(|path| {
+            content.push_str(path);
+            content.push_str("\n");
+        });
+    }
     content
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -18,6 +18,7 @@ pub struct Image {
     pub caches: Option<Vec<String>>,
     // Specific part
     pub builders: Option<Vec<Builder>>,
+    pub context: Option<Vec<String>>,
     pub ignores: Option<Vec<String>>,
     pub entrypoint: Option<Vec<String>>,
     pub cmd: Option<Vec<String>>,


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes #174 
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

I added a new `context` field that can work in complement to `ignores`. The `context` field ignores everything and exclude from the ignore the specified paths.

The `ignores` field values are added to the `.dockerignore` file after the `context` values.

## Technical highlight/advice

Nothing

## How to test my changes
The `dofigen.yml` file in this project replaces the `ignores` by `context`.


## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


