### PR TITLE
feat!: Permissive serde as feature

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -134,7 +134,7 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --release -F cli --target ${{ matrix.target }}
+        args: --release -F cli -F permissive --target ${{ matrix.target }}
 
     - name: Zip
       if: ${{ matrix.os == 'windows' }}

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -63,7 +63,13 @@ jobs:
         command: build
         args: --verbose
 
-    - name: Test
+    - name: Test base
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --verbose
+
+    - name: Test all features
       uses: actions-rs/cargo@v1
       with:
         command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/bin/main.rs"
 required-features = ["cli"]
 
 [features]
+# default = ["permissive"]
 cli = ["clap"]
 json_schema = ["schemars", "serde_json"]
 permissive = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ required-features = ["cli"]
 [features]
 cli = ["clap"]
 json_schema = ["schemars", "serde_json"]
+permissive = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/bin/main.rs"
 required-features = ["cli"]
 
 [features]
-# default = ["permissive"]
 cli = ["clap"]
 json_schema = ["schemars", "serde_json"]
 permissive = []

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ First install Cargo, the Rust package manager: https://doc.rust-lang.org/cargo/g
 Then use the following command to install dofigen:
 
 ```bash
-cargo install dofigen -F cli
+cargo install dofigen -F cli -F permissive
 ```
 
 #### Download the binary

--- a/dofigen.yml
+++ b/dofigen.yml
@@ -6,7 +6,7 @@ builders:
     add: "."
     run:
     # Build with musl to work with scratch
-    - cargo build --release -F cli
+    - cargo build --release -F cli -F permissive
     # copy the generated binary outside of the target directory. If not the other stages won't be able to find it since it's in a cache volume
     - mv target/x86_64-unknown-linux-musl/release/dofigen /app/
     cache:

--- a/src/bin/commands/generate.rs
+++ b/src/bin/commands/generate.rs
@@ -52,7 +52,7 @@ impl CliCommand for Generate {
                 eprintln!("No Dofigen file found");
                 std::process::exit(1);
             }
-            &files[0].to_string()
+            &files[0].into()
         };
         let image = if file == "-" {
             from_reader(std::io::stdin())

--- a/src/dockerfile_struct.rs
+++ b/src/dockerfile_struct.rs
@@ -36,8 +36,8 @@ pub struct InstructionOptionOption {
 impl InstructionOptionOption {
     pub fn new(name: &str, value: &str) -> Self {
         Self {
-            name: name.to_string(),
-            value: value.to_string(),
+            name: name.into(),
+            value: value.into(),
         }
     }
 }
@@ -51,7 +51,7 @@ impl DockerfileContent for DockerfileLine {
                 .map(|l| format!("# {}", l))
                 .collect::<Vec<String>>()
                 .join("\n"),
-            DockerfileLine::Empty => "".to_string(),
+            DockerfileLine::Empty => "".into(),
         }
     }
 }
@@ -103,11 +103,11 @@ mod test {
     #[test]
     fn test_generate_content_instruction() {
         let instruction = DockerfileInsctruction {
-            command: "RUN".to_string(),
-            content: "echo 'Hello, World!'".to_string(),
+            command: "RUN".into(),
+            content: "echo 'Hello, World!'".into(),
             options: vec![
-                InstructionOption::NameOnly("arg1".to_string()),
-                InstructionOption::WithValue("arg2".to_string(), "value2".to_string()),
+                InstructionOption::NameOnly("arg1".into()),
+                InstructionOption::WithValue("arg2".into(), "value2".into()),
             ],
         };
         assert_eq!(
@@ -118,7 +118,7 @@ mod test {
 
     #[test]
     fn test_generate_content_comment() {
-        let comment = DockerfileLine::Comment("This is a comment".to_string());
+        let comment = DockerfileLine::Comment("This is a comment".into());
         assert_eq!(comment.generate_content(), "# This is a comment");
     }
 
@@ -130,13 +130,13 @@ mod test {
 
     #[test]
     fn test_generate_content_name_only_option() {
-        let option = InstructionOption::NameOnly("arg1".to_string());
+        let option = InstructionOption::NameOnly("arg1".into());
         assert_eq!(option.generate_content(), "--arg1");
     }
 
     #[test]
     fn test_generate_content_with_value_option() {
-        let option = InstructionOption::WithValue("arg1".to_string(), "value1".to_string());
+        let option = InstructionOption::WithValue("arg1".into(), "value1".into());
         assert_eq!(option.generate_content(), "--arg1=value1");
     }
 
@@ -145,7 +145,7 @@ mod test {
         let sub_option1 = InstructionOptionOption::new("sub_arg1", "sub_value1");
         let sub_option2 = InstructionOptionOption::new("sub_arg2", "sub_value2");
         let options = vec![sub_option1, sub_option2];
-        let option = InstructionOption::WithOptions("arg1".to_string(), options);
+        let option = InstructionOption::WithOptions("arg1".into(), options);
         let expected = "--arg1=sub_arg1=sub_value1,sub_arg2=sub_value2";
         assert_eq!(option.generate_content(), expected);
     }

--- a/src/dofigen_struct.rs
+++ b/src/dofigen_struct.rs
@@ -1,11 +1,19 @@
 #[cfg(feature = "permissive")]
-use crate::serde_permissive::{
-    deserialize_one_or_many, deserialize_optional_one_or_many, PermissiveStruct,
-};
+use crate::serde_permissive::{OneOrManyVec, ParsableStruct};
 #[cfg(feature = "json_schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[cfg(feature = "permissive")]
+pub type PermissiveStruct<T> = ParsableStruct<T>;
+#[cfg(not(feature = "permissive"))]
+pub type PermissiveStruct<T> = Box<T>;
+
+#[cfg(feature = "permissive")]
+pub type PermissiveVec<T> = OneOrManyVec<T>;
+#[cfg(not(feature = "permissive"))]
+pub type PermissiveVec<T> = Box<Vec<T>>;
 
 /** Represents the Dockerfile main stage */
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -14,60 +22,28 @@ use std::collections::HashMap;
 pub struct Image {
     // Common part
     #[serde(alias = "image")]
-    pub from: Option<ImageName>,
-    pub user: Option<User>,
+    pub from: Option<PermissiveStruct<ImageName>>,
+    pub user: Option<PermissiveStruct<User>>,
     pub workdir: Option<String>,
     #[serde(alias = "envs")]
     pub env: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
     #[serde(alias = "add", alias = "adds")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub copy: Option<Vec<CopyResource>>,
+    pub copy: Option<PermissiveVec<PermissiveStruct<CopyResource>>>,
     pub root: Option<Root>,
     #[serde(alias = "script")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub run: Option<Vec<String>>,
+    pub run: Option<PermissiveVec<String>>,
     #[serde(alias = "caches")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub cache: Option<Vec<String>>,
+    pub cache: Option<PermissiveVec<String>>,
     // Specific part
     pub builders: Option<Vec<Builder>>,
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub context: Option<Vec<String>>,
+    pub context: Option<PermissiveVec<String>>,
     #[serde(alias = "ignores")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub ignore: Option<Vec<String>>,
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub entrypoint: Option<Vec<String>>,
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub cmd: Option<Vec<String>>,
+    pub ignore: Option<PermissiveVec<String>>,
+    pub entrypoint: Option<PermissiveVec<String>>,
+    pub cmd: Option<PermissiveVec<String>>,
     #[serde(alias = "port", alias = "ports")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub expose: Option<Vec<Port>>,
+    pub expose: Option<PermissiveVec<PermissiveStruct<Port>>>,
     pub healthcheck: Option<Healthcheck>,
 }
 
@@ -77,31 +53,19 @@ pub struct Image {
 pub struct Builder {
     // Common part
     #[serde(alias = "image")]
-    pub from: ImageName,
-    pub user: Option<User>,
+    pub from: PermissiveStruct<ImageName>,
+    pub user: Option<PermissiveStruct<User>>,
     pub workdir: Option<String>,
     #[serde(alias = "envs")]
     pub env: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
     #[serde(alias = "add", alias = "adds")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub copy: Option<Vec<CopyResource>>,
+    pub copy: Option<PermissiveVec<PermissiveStruct<CopyResource>>>,
     pub root: Option<Root>,
     #[serde(alias = "script")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub run: Option<Vec<String>>,
+    pub run: Option<PermissiveVec<String>>,
     #[serde(alias = "caches")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub cache: Option<Vec<String>>,
+    pub cache: Option<PermissiveVec<String>>,
     // Specific part
     pub name: Option<String>,
 }
@@ -119,17 +83,9 @@ pub struct Artifact {
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Root {
     #[serde(alias = "script")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub run: Option<Vec<String>>,
+    pub run: Option<PermissiveVec<String>>,
     #[serde(alias = "caches")]
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub cache: Option<Vec<String>>,
+    pub cache: Option<PermissiveVec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -142,8 +98,7 @@ pub struct Healthcheck {
     pub retries: Option<u16>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<ImageName>"))]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct ImageName {
     pub host: Option<String>,
@@ -159,9 +114,8 @@ pub enum ImageVersion {
     Digest(String),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
-#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<CopyResource>"))]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum CopyResource {
     Copy(Copy),
@@ -171,27 +125,14 @@ pub enum CopyResource {
 
 /// Represents the COPY instruction in a Dockerfile.
 /// See https://docs.docker.com/reference/dockerfile/#copy
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Copy {
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_one_or_many", default)
-    )]
-    pub paths: Vec<String>,
-    pub target: Option<String>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
-    pub chown: Option<User>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
-    pub chmod: Option<String>,
+    pub paths: PermissiveVec<String>,
+    #[serde(flatten)]
+    pub options: CopyOptions,
     /// See https://docs.docker.com/reference/dockerfile/#copy---exclude
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub exclude: Option<Vec<String>>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---link
-    pub link: Option<bool>,
+    pub exclude: Option<PermissiveVec<String>>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---parents
     pub parents: Option<bool>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---from
@@ -200,40 +141,34 @@ pub struct Copy {
 
 /// Represents the ADD instruction in a Dockerfile specific for Git repo.
 /// See https://docs.docker.com/reference/dockerfile/#adding-private-git-repositories
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct AddGitRepo {
     pub repo: String,
-    // pub repo: GitRepo,
-    pub target: Option<String>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
-    pub chown: Option<User>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
-    pub chmod: Option<String>,
+    #[serde(flatten)]
+    pub options: CopyOptions,
     /// See https://docs.docker.com/reference/dockerfile/#copy---exclude
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_optional_one_or_many", default)
-    )]
-    pub exclude: Option<Vec<String>>,
-    /// See https://docs.docker.com/reference/dockerfile/#copy---link
-    pub link: Option<bool>,
+    pub exclude: Option<PermissiveVec<String>>,
     /// See https://docs.docker.com/reference/dockerfile/#add---keep-git-dir
     pub keep_git_dir: Option<bool>,
 }
 
 /// Represents the ADD instruction in a Dockerfile file from URLs or uncompress an archive.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Add {
-    #[cfg_attr(
-        feature = "permissive",
-        serde(deserialize_with = "deserialize_one_or_many", default)
-    )]
-    pub files: Vec<String>,
-    pub target: Option<String>,
+    pub files: PermissiveVec<String>,
+    #[serde(flatten)]
+    pub options: CopyOptions,
     /// See https://docs.docker.com/reference/dockerfile/#add---checksum
     pub checksum: Option<String>,
+}
+
+/// Represents the ADD instruction in a Dockerfile file from URLs or uncompress an archive.
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
+pub struct CopyOptions {
+    pub target: Option<String>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
     pub chown: Option<User>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
@@ -242,16 +177,14 @@ pub struct Add {
     pub link: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<User>"))]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct User {
     pub user: String,
     pub group: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<Port>"))]
+#[derive(Serialize, Debug, Clone, PartialEq, Default, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Port {
     pub port: u16,
@@ -290,65 +223,99 @@ pub enum PortProtocol {
 mod test {
     use super::*;
 
-    mod copy_resource {
+    mod deserialize {
         use super::*;
 
-        #[test]
-        fn deserialize_copy() {
-            let json_data = r#"{
-            "paths": ["file1.txt", "file2.txt"],
-            "target": "destination/",
-            "chown": {
-                "user": "root",
-                "group": "root"
-            },
-            "chmod": "755",
-            "exclude": ["file3.txt"],
-            "link": true,
-            "parents": true,
-            "from": "source/"
-        }"#;
+        mod user {
+            use super::*;
 
-            let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
+            #[test]
+            fn name_and_group() {
+                let json_data = r#"{
+    "user": "test",
+    "group": "test"
+}"#;
 
-            assert_eq!(
-                copy_resource,
-                CopyResource::Copy(Copy {
-                    paths: vec!["file1.txt".to_string(), "file2.txt".to_string()],
-                    target: Some("destination/".to_string()),
-                    chown: Some(User {
-                        user: "root".to_string(),
-                        group: Some("root".to_string())
-                    }),
-                    chmod: Some("755".to_string()),
-                    exclude: Some(vec!["file3.txt".to_string()]),
-                    link: Some(true),
-                    parents: Some(true),
-                    from: Some("source/".to_string())
-                })
-            );
+                let user: User = serde_yaml::from_str(json_data).unwrap();
+
+                assert_eq!(
+                    user,
+                    User {
+                        user: "test".into(),
+                        group: Some("test".into())
+                    }
+                );
+            }
         }
 
-        #[cfg(feature = "permissive")]
-        #[test]
-        fn deserialize_copy_from_str() {
-            let json_data = "file1.txt destination/";
+        mod copy_resource {
 
-            let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
+            use super::*;
 
-            assert_eq!(
-                copy_resource,
-                CopyResource::Copy(Copy {
-                    paths: vec!["file1.txt".to_string()],
-                    target: Some("destination/".to_string()),
-                    ..Default::default()
-                })
-            );
-        }
+            #[test]
+            fn deserialize_copy() {
+                let json_data = r#"{
+    "paths": ["file1.txt", "file2.txt"],
+    "target": "destination/",
+    "chown": {
+        "user": "root",
+        "group": "root"
+    },
+    "chmod": "755",
+    "exclude": ["file3.txt"],
+    "link": true,
+    "parents": true,
+    "from": "source/"
+}"#;
 
-        #[test]
-        fn deserialize_add_git_repo() {
-            let json_data = r#"{
+                let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
+
+                assert_eq!(
+                    copy_resource,
+                    CopyResource::Copy(Copy {
+                        paths: vec!["file1.txt".into(), "file2.txt".into()].into(),
+                        options: CopyOptions {
+                            target: Some("destination/".into()),
+                            chown: Some(User {
+                                user: "root".into(),
+                                group: Some("root".into())
+                            }),
+                            chmod: Some("755".into()),
+                            link: Some(true),
+                        },
+                        exclude: Some(vec!["file3.txt".into()].into()),
+                        parents: Some(true),
+                        from: Some("source/".into())
+                    })
+                );
+            }
+
+            #[cfg(feature = "permissive")]
+            #[test]
+            fn deserialize_copy_from_str() {
+                use std::ops::Deref;
+
+                let json_data = "file1.txt destination/";
+
+                let copy_resource: PermissiveStruct<CopyResource> =
+                    serde_yaml::from_str(json_data).unwrap();
+
+                assert_eq!(
+                    copy_resource.deref(),
+                    &CopyResource::Copy(Copy {
+                        paths: vec!["file1.txt".into()].into(),
+                        options: CopyOptions {
+                            target: Some("destination/".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    })
+                );
+            }
+
+            #[test]
+            fn deserialize_add_git_repo() {
+                let json_data = r#"{
             "repo": "https://github.com/example/repo.git",
             "target": "destination/",
             "chown": {
@@ -361,28 +328,30 @@ mod test {
             "keep_git_dir": true
         }"#;
 
-            let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
+                let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
 
-            assert_eq!(
-                copy_resource,
-                CopyResource::AddGitRepo(AddGitRepo {
-                    repo: "https://github.com/example/repo.git".to_string(),
-                    target: Some("destination/".to_string()),
-                    chown: Some(User {
-                        user: "root".to_string(),
-                        group: Some("root".to_string())
-                    }),
-                    chmod: Some("755".to_string()),
-                    exclude: Some(vec!["file3.txt".to_string()]),
-                    link: Some(true),
-                    keep_git_dir: Some(true)
-                })
-            );
-        }
+                assert_eq!(
+                    copy_resource,
+                    CopyResource::AddGitRepo(AddGitRepo {
+                        repo: "https://github.com/example/repo.git".into(),
+                        options: CopyOptions {
+                            target: Some("destination/".into()),
+                            chown: Some(User {
+                                user: "root".into(),
+                                group: Some("root".into())
+                            }),
+                            chmod: Some("755".into()),
+                            link: Some(true),
+                        },
+                        exclude: Some(vec!["file3.txt".into()].into()),
+                        keep_git_dir: Some(true)
+                    })
+                );
+            }
 
-        #[test]
-        fn deserialize_add() {
-            let json_data = r#"{
+            #[test]
+            fn deserialize_add() {
+                let json_data = r#"{
             "files": ["file1.txt", "file2.txt"],
             "target": "destination/",
             "checksum": "sha256:abcdef123456",
@@ -394,22 +363,25 @@ mod test {
             "link": true
         }"#;
 
-            let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
+                let copy_resource: CopyResource = serde_yaml::from_str(json_data).unwrap();
 
-            assert_eq!(
-                copy_resource,
-                CopyResource::Add(Add {
-                    files: vec!["file1.txt".to_string(), "file2.txt".to_string()],
-                    target: Some("destination/".to_string()),
-                    checksum: Some("sha256:abcdef123456".to_string()),
-                    chown: Some(User {
-                        user: "root".to_string(),
-                        group: Some("root".to_string())
-                    }),
-                    chmod: Some("755".to_string()),
-                    link: Some(true)
-                })
-            );
+                assert_eq!(
+                    copy_resource,
+                    CopyResource::Add(Add {
+                        files: vec!["file1.txt".into(), "file2.txt".into()].into(),
+                        options: CopyOptions {
+                            target: Some("destination/".into()),
+                            chown: Some(User {
+                                user: "root".into(),
+                                group: Some("root".into())
+                            }),
+                            chmod: Some("755".into()),
+                            link: Some(true),
+                        },
+                        checksum: Some("sha256:abcdef123456".into()),
+                    })
+                );
+            }
         }
     }
 }

--- a/src/dofigen_struct.rs
+++ b/src/dofigen_struct.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "json_schema")]
-use schemars::JsonSchema;
-
+#[cfg(feature = "permissive")]
 use crate::serde_permissive::{
     deserialize_one_or_many, deserialize_optional_one_or_many, PermissiveStruct,
 };
+#[cfg(feature = "json_schema")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -20,45 +20,52 @@ pub struct Image {
     #[serde(alias = "envs")]
     pub env: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
-    #[serde(
-        alias = "add",
-        alias = "adds",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "add", alias = "adds")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub copy: Option<Vec<CopyResources>>,
     pub root: Option<Root>,
-    #[serde(
-        alias = "script",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "script")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub run: Option<Vec<String>>,
-    #[serde(
-        alias = "caches",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "caches")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub cache: Option<Vec<String>>,
     // Specific part
     pub builders: Option<Vec<Builder>>,
-    #[serde(deserialize_with = "deserialize_optional_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
+    )]
     pub context: Option<Vec<String>>,
-    #[serde(
-        alias = "ignores",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "ignores")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub ignore: Option<Vec<String>>,
-    #[serde(deserialize_with = "deserialize_optional_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
+    )]
     pub entrypoint: Option<Vec<String>>,
-    #[serde(deserialize_with = "deserialize_optional_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
+    )]
     pub cmd: Option<Vec<String>>,
-    #[serde(
-        alias = "port",
-        alias = "ports",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "port", alias = "ports")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub expose: Option<Vec<Port>>,
     pub healthcheck: Option<Healthcheck>,
@@ -76,24 +83,23 @@ pub struct Builder {
     #[serde(alias = "envs")]
     pub env: Option<HashMap<String, String>>,
     pub artifacts: Option<Vec<Artifact>>,
-    #[serde(
-        alias = "add",
-        alias = "adds",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "add", alias = "adds")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub copy: Option<Vec<CopyResources>>,
     pub root: Option<Root>,
-    #[serde(
-        alias = "script",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "script")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub run: Option<Vec<String>>,
-    #[serde(
-        alias = "caches",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "caches")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub cache: Option<Vec<String>>,
     // Specific part
@@ -112,16 +118,16 @@ pub struct Artifact {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Root {
-    #[serde(
-        alias = "script",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "script")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub run: Option<Vec<String>>,
-    #[serde(
-        alias = "caches",
-        deserialize_with = "deserialize_optional_one_or_many",
-        default
+    #[serde(alias = "caches")]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
     )]
     pub cache: Option<Vec<String>>,
 }
@@ -137,7 +143,7 @@ pub struct Healthcheck {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(from = "PermissiveStruct<ImageName>")]
+#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<ImageName>"))]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct ImageName {
     pub host: Option<String>,
@@ -154,7 +160,10 @@ pub enum ImageVersion {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(from = "PermissiveStruct<CopyResources>")]
+#[cfg_attr(
+    feature = "permissive",
+    serde(from = "PermissiveStruct<CopyResources>")
+)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub enum CopyResources {
     Copy(Copy),
@@ -167,7 +176,10 @@ pub enum CopyResources {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Copy {
-    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_one_or_many", default)
+    )]
     pub paths: Vec<String>,
     pub target: Option<String>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
@@ -175,7 +187,10 @@ pub struct Copy {
     /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
     pub chmod: Option<String>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---exclude
-    #[serde(deserialize_with = "deserialize_optional_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
+    )]
     pub exclude: Option<Vec<String>>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---link
     pub link: Option<bool>,
@@ -198,7 +213,10 @@ pub struct AddGitRepo {
     /// See https://docs.docker.com/reference/dockerfile/#copy---chown---chmod
     pub chmod: Option<String>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---exclude
-    #[serde(deserialize_with = "deserialize_optional_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_optional_one_or_many", default)
+    )]
     pub exclude: Option<Vec<String>>,
     /// See https://docs.docker.com/reference/dockerfile/#copy---link
     pub link: Option<bool>,
@@ -210,7 +228,10 @@ pub struct AddGitRepo {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Add {
-    #[serde(deserialize_with = "deserialize_one_or_many", default)]
+    #[cfg_attr(
+        feature = "permissive",
+        serde(deserialize_with = "deserialize_one_or_many", default)
+    )]
     pub paths: Vec<String>,
     pub target: Option<String>,
     /// See https://docs.docker.com/reference/dockerfile/#add---checksum
@@ -224,7 +245,7 @@ pub struct Add {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(from = "PermissiveStruct<User>")]
+#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<User>"))]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct User {
     pub user: String,
@@ -232,7 +253,7 @@ pub struct User {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(from = "PermissiveStruct<Port>")]
+#[cfg_attr(feature = "permissive", serde(from = "PermissiveStruct<Port>"))]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Port {
     pub port: u16,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Error while deserializing the document{}: {0}", location_to_string(.0.location()))]
+    #[error("Error while deserializing the document{}: {0}", location_into(.0.location()))]
     Deserialize(#[from] serde_yaml::Error),
     #[error("{0}")]
     Format(#[from] std::fmt::Error),
@@ -13,8 +13,8 @@ pub enum Error {
     Custom(String),
 }
 
-fn location_to_string(location: Option<Location>) -> String {
+fn location_into(location: Option<Location>) -> String {
     location
         .map(|location| format!(" at line {}, column {}", location.line(), location.column()))
-        .unwrap_or_else(|| "".to_string())
+        .unwrap_or_else(|| "".into())
 }

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -1,27 +1,10 @@
 use crate::{
-    serde_permissive::PermissiveStruct, Add, AddGitRepo, Copy, CopyResource, ImageName,
-    ImageVersion, Port, PortProtocol, User,
+    Add, AddGitRepo, Copy, CopyOptions, CopyResource, ImageName, ImageVersion, Port, PortProtocol,
+    User,
 };
 use regex::Regex;
 use serde::de::{value::Error, Error as DeError};
 use std::str::FromStr;
-
-macro_rules! impl_PermissiveStruct {
-    (for $($t:ty),+) => {
-        $(impl From<PermissiveStruct<$t>> for $t {
-            fn from(s: PermissiveStruct<$t>) -> Self {
-                match s {
-                    PermissiveStruct::Int(s) => s.to_string().parse().unwrap(),
-                    PermissiveStruct::Uint(s) => s.to_string().parse().unwrap(),
-                    PermissiveStruct::String(s) => s.parse().unwrap(),
-                    PermissiveStruct::Struct(s) => s,
-                }
-            }
-        })*
-    }
-}
-
-impl_PermissiveStruct!(for ImageName, CopyResource, Copy, User, Port);
 
 const GIT_HTTP_REPO_REGEX: &str = "https?://(?:.+@)?[a-zA-Z0-9_-]+(?:\\.[a-zA-Z0-9_-]+)+/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\\.git(?:#[a-zA-Z0-9_/.-]*(?::[a-zA-Z0-9_/-]+)?)?";
 const GIT_SSH_REPO_REGEX: &str = "[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(?:\\.[a-zA-Z0-9_-]+)+:[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(?:#[a-zA-Z0-9_/.-]+)?(?::[a-zA-Z0-9_/-]+)?";
@@ -36,9 +19,9 @@ impl FromStr for ImageName {
             return Err(Error::custom("Not matching image name pattern"));
         };
         Ok(ImageName {
-            host: captures.name("host").map(|m| m.as_str().to_string()),
+            host: captures.name("host").map(|m| m.as_str().into()),
             port: captures.name("port").map(|m| m.as_str().parse().unwrap()),
-            path: captures["path"].to_string(),
+            path: captures["path"].into(),
             version: match (
                 captures.name("version_char").map(|m| m.as_str()),
                 captures.name("version_value"),
@@ -80,11 +63,14 @@ impl FromStr for Copy {
     type Err = Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let mut parts: Vec<String> = s.split(" ").map(|s| s.to_string()).collect();
+        let mut parts: Vec<String> = s.split(" ").map(|s| s.into()).collect();
         let target = if parts.len() > 1 { parts.pop() } else { None };
         Ok(Copy {
-            paths: parts.clone(),
-            target: target,
+            paths: parts.into(),
+            options: CopyOptions {
+                target: target,
+                ..Default::default()
+            },
             ..Default::default()
         })
     }
@@ -101,7 +87,10 @@ impl FromStr for AddGitRepo {
         };
         Ok(AddGitRepo {
             repo: repo,
-            target: target,
+            options: CopyOptions {
+                target: target,
+                ..Default::default()
+            },
             ..Default::default()
         })
     }
@@ -111,11 +100,14 @@ impl FromStr for Add {
     type Err = Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let mut parts: Vec<String> = s.split(" ").map(|s| s.to_string()).collect();
+        let mut parts: Vec<String> = s.split(" ").map(|s| s.into()).collect();
         let target = if parts.len() > 1 { parts.pop() } else { None };
         Ok(Add {
-            files: parts,
-            target: target,
+            files: parts.into(),
+            options: CopyOptions {
+                target: target,
+                ..Default::default()
+            },
             ..Default::default()
         })
     }
@@ -216,18 +208,22 @@ mod test_from_str {
         }
     }
 
+    fn check_empty_copy_options(options: &CopyOptions) {
+        assert!(options.target.is_none());
+        assert!(options.chown.is_none());
+        assert!(options.chmod.is_none());
+        assert!(options.link.is_none());
+    }
+
     mod copy {
         use super::*;
 
         #[test]
         fn simple() {
             let result = Copy::from_str("src").unwrap();
-            assert_eq!(result.paths, vec!["src".to_string()]);
-            assert!(result.target.is_none());
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            assert_eq!(result.paths, vec!["src".into()].into());
+            check_empty_copy_options(&result.options);
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.parents.is_none());
             assert!(result.from.is_none());
         }
@@ -235,12 +231,12 @@ mod test_from_str {
         #[test]
         fn with_target_option() {
             let result = Copy::from_str("src /app").unwrap();
-            assert_eq!(result.paths, vec!["src".to_string()]);
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            assert_eq!(result.paths, vec!["src".into()].into());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.parents.is_none());
             assert!(result.from.is_none());
         }
@@ -248,12 +244,12 @@ mod test_from_str {
         #[test]
         fn with_multiple_sources_and_target() {
             let result = Copy::from_str("src1 src2 /app").unwrap();
-            assert_eq!(result.paths, vec!["src1".to_string(), "src2".to_string()]);
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            assert_eq!(result.paths, vec!["src1".into(), "src2".into()].into());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.parents.is_none());
             assert!(result.from.is_none());
         }
@@ -266,11 +262,8 @@ mod test_from_str {
         fn ssh() {
             let result = AddGitRepo::from_str("git@github.com:lenra-io/dofigen.git").unwrap();
             assert_eq!(result.repo, "git@github.com:lenra-io/dofigen.git");
-            assert!(result.target.is_none());
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            check_empty_copy_options(&result.options);
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.keep_git_dir.is_none());
         }
 
@@ -278,11 +271,11 @@ mod test_from_str {
         fn ssh_with_target() {
             let result = AddGitRepo::from_str("git@github.com:lenra-io/dofigen.git /app").unwrap();
             assert_eq!(result.repo, "git@github.com:lenra-io/dofigen.git");
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.keep_git_dir.is_none());
         }
 
@@ -290,11 +283,8 @@ mod test_from_str {
         fn http() {
             let result = AddGitRepo::from_str("https://github.com/lenra-io/dofigen.git").unwrap();
             assert_eq!(result.repo, "https://github.com/lenra-io/dofigen.git");
-            assert!(result.target.is_none());
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            check_empty_copy_options(&result.options);
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.keep_git_dir.is_none());
         }
 
@@ -303,11 +293,11 @@ mod test_from_str {
             let result =
                 AddGitRepo::from_str("https://github.com/lenra-io/dofigen.git /app").unwrap();
             assert_eq!(result.repo, "https://github.com/lenra-io/dofigen.git");
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
             assert!(result.exclude.is_none());
-            assert!(result.link.is_none());
             assert!(result.keep_git_dir.is_none());
         }
     }
@@ -321,12 +311,9 @@ mod test_from_str {
                 Add::from_str("https://github.com/lenra-io/dofigen/raw/main/README.md").unwrap();
             assert_eq!(
                 result.files,
-                vec!["https://github.com/lenra-io/dofigen/raw/main/README.md".to_string()]
+                vec!["https://github.com/lenra-io/dofigen/raw/main/README.md".into()].into()
             );
-            assert!(result.target.is_none());
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
-            assert!(result.link.is_none());
+            check_empty_copy_options(&result.options);
         }
 
         #[test]
@@ -336,12 +323,12 @@ mod test_from_str {
                     .unwrap();
             assert_eq!(
                 result.files,
-                vec!["https://github.com/lenra-io/dofigen/raw/main/README.md".to_string()]
+                vec!["https://github.com/lenra-io/dofigen/raw/main/README.md".into()].into()
             );
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
-            assert!(result.link.is_none());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
         }
 
         #[test]
@@ -350,14 +337,14 @@ mod test_from_str {
             assert_eq!(
                 result.files,
                 vec![
-                    "https://github.com/lenra-io/dofigen/raw/main/README.md".to_string(),
-                    "https://github.com/lenra-io/dofigen/raw/main/LICENSE".to_string()
-                ]
+                    "https://github.com/lenra-io/dofigen/raw/main/README.md".into(),
+                    "https://github.com/lenra-io/dofigen/raw/main/LICENSE".into()
+                ].into()
             );
-            assert_eq!(result.target, Some("/app".to_string()));
-            assert!(result.chown.is_none());
-            assert!(result.chmod.is_none());
-            assert!(result.link.is_none());
+            assert_eq!(result.options.target, Some("/app".into()));
+            assert!(result.options.chown.is_none());
+            assert!(result.options.chmod.is_none());
+            assert!(result.options.link.is_none());
         }
     }
 
@@ -383,8 +370,7 @@ mod test_from_str {
 
         #[test]
         fn add_git_repo_http() {
-            let result =
-                CopyResource::from_str("https://github.com/lenra-io/dofigen.git").unwrap();
+            let result = CopyResource::from_str("https://github.com/lenra-io/dofigen.git").unwrap();
             assert_eq!(
                 result,
                 CopyResource::AddGitRepo(

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -339,7 +339,8 @@ mod test_from_str {
                 vec![
                     "https://github.com/lenra-io/dofigen/raw/main/README.md".into(),
                     "https://github.com/lenra-io/dofigen/raw/main/LICENSE".into()
-                ].into()
+                ]
+                .into()
             );
             assert_eq!(result.options.target, Some("/app".into()));
             assert!(result.options.chown.is_none());

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,7 +1,7 @@
 use crate::{
     dockerfile_struct::{DockerfileInsctruction, DockerfileLine, InstructionOption},
     script_runner::ScriptRunner,
-    Add, AddGitRepo, Artifact, BaseStage, Copy, CopyResources, Image, ImageName, ImageVersion,
+    Add, AddGitRepo, Artifact, BaseStage, Copy, CopyResource, Image, ImageName, ImageVersion,
     Port, PortProtocol, Result, Stage, User, DOCKERFILE_VERSION,
 };
 
@@ -83,15 +83,15 @@ impl ToString for PortProtocol {
     }
 }
 
-impl DockerfileGenerator for CopyResources {
+impl DockerfileGenerator for CopyResource {
     fn generate_dockerfile_lines(
         &self,
         context: &GenerationContext,
     ) -> Result<Vec<DockerfileLine>> {
         match self {
-            CopyResources::Copy(copy) => copy.generate_dockerfile_lines(context),
-            CopyResources::Add(add_web_file) => add_web_file.generate_dockerfile_lines(context),
-            CopyResources::AddGitRepo(add_git_repo) => {
+            CopyResource::Copy(copy) => copy.generate_dockerfile_lines(context),
+            CopyResource::Add(add_web_file) => add_web_file.generate_dockerfile_lines(context),
+            CopyResource::AddGitRepo(add_git_repo) => {
                 add_git_repo.generate_dockerfile_lines(context)
             }
         }
@@ -173,7 +173,7 @@ impl DockerfileGenerator for Add {
 
         Ok(vec![DockerfileLine::Instruction(DockerfileInsctruction {
             command: "ADD".to_string(),
-            content: copy_paths_to_string(&self.paths, &self.target),
+            content: copy_paths_to_string(&self.files, &self.target),
             options,
         })])
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -104,16 +104,10 @@ fn add_copy_options(
     context: &GenerationContext,
 ) {
     if let Some(chown) = copy_options.chown.as_ref().or(context.user.as_ref()) {
-        inst_options.push(InstructionOption::WithValue(
-            "chown".into(),
-            chown.into(),
-        ));
+        inst_options.push(InstructionOption::WithValue("chown".into(), chown.into()));
     }
     if let Some(chmod) = &copy_options.chmod {
-        inst_options.push(InstructionOption::WithValue(
-            "chmod".into(),
-            chmod.into(),
-        ));
+        inst_options.push(InstructionOption::WithValue("chmod".into(), chmod.into()));
     }
     if copy_options.link.unwrap_or(true) {
         inst_options.push(InstructionOption::NameOnly("link".into()));
@@ -127,10 +121,7 @@ impl DockerfileGenerator for Copy {
     ) -> Result<Vec<DockerfileLine>> {
         let mut options: Vec<InstructionOption> = vec![];
         if let Some(from) = &self.from {
-            options.push(InstructionOption::WithValue(
-                "from".into(),
-                from.into(),
-            ));
+            options.push(InstructionOption::WithValue("from".into(), from.into()));
         }
         add_copy_options(&mut options, &self.options, context);
         // excludes are not supported yet: minimal version 1.7-labs
@@ -474,11 +465,7 @@ mod test {
                 ..Default::default()
             };
             let name = image.name(&GenerationContext {
-                previous_builders: vec![
-                    "builder-0".into(),
-                    "builder-1".into(),
-                    "builder-2".into(),
-                ],
+                previous_builders: vec!["builder-0".into(), "builder-1".into(), "builder-2".into()],
                 ..Default::default()
             });
             assert_eq!(name, "runtime");

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,8 +1,8 @@
 use crate::{
     dockerfile_struct::{DockerfileInsctruction, DockerfileLine, InstructionOption},
     script_runner::ScriptRunner,
-    Add, AddGitRepo, Artifact, BaseStage, Copy, CopyResource, Image, ImageName, ImageVersion,
-    Port, PortProtocol, Result, Stage, User, DOCKERFILE_VERSION,
+    Add, AddGitRepo, Artifact, BaseStage, Copy, CopyOptions, CopyResource, Image, ImageName,
+    ImageVersion, Port, PortProtocol, Result, Stage, User, DOCKERFILE_VERSION,
 };
 
 pub const LINE_SEPARATOR: &str = " \\\n    ";
@@ -77,8 +77,8 @@ impl ToString for Port {
 impl ToString for PortProtocol {
     fn to_string(&self) -> String {
         match self {
-            PortProtocol::Tcp => "tcp".to_string(),
-            PortProtocol::Udp => "udp".to_string(),
+            PortProtocol::Tcp => "tcp".into(),
+            PortProtocol::Udp => "udp".into(),
         }
     }
 }
@@ -98,6 +98,28 @@ impl DockerfileGenerator for CopyResource {
     }
 }
 
+fn add_copy_options(
+    inst_options: &mut Vec<InstructionOption>,
+    copy_options: &CopyOptions,
+    context: &GenerationContext,
+) {
+    if let Some(chown) = copy_options.chown.as_ref().or(context.user.as_ref()) {
+        inst_options.push(InstructionOption::WithValue(
+            "chown".into(),
+            chown.into(),
+        ));
+    }
+    if let Some(chmod) = &copy_options.chmod {
+        inst_options.push(InstructionOption::WithValue(
+            "chmod".into(),
+            chmod.into(),
+        ));
+    }
+    if copy_options.link.unwrap_or(true) {
+        inst_options.push(InstructionOption::NameOnly("link".into()));
+    }
+}
+
 impl DockerfileGenerator for Copy {
     fn generate_dockerfile_lines(
         &self,
@@ -106,38 +128,24 @@ impl DockerfileGenerator for Copy {
         let mut options: Vec<InstructionOption> = vec![];
         if let Some(from) = &self.from {
             options.push(InstructionOption::WithValue(
-                "from".to_string(),
-                from.to_string(),
+                "from".into(),
+                from.into(),
             ));
         }
-        if let Some(chown) = self.chown.as_ref().or(context.user.as_ref()) {
-            options.push(InstructionOption::WithValue(
-                "chown".to_string(),
-                chown.to_string(),
-            ));
-        }
-        if let Some(chmod) = &self.chmod {
-            options.push(InstructionOption::WithValue(
-                "chmod".to_string(),
-                chmod.to_string(),
-            ));
-        }
+        add_copy_options(&mut options, &self.options, context);
         // excludes are not supported yet: minimal version 1.7-labs
         // if let Some(exclude) = &self.exclude {
         //     for path in exclude.clone().to_vec() {
-        //         options.push(InstructionOption::WithValue("exclude".to_string(), path));
+        //         options.push(InstructionOption::WithValue("exclude".into(), path));
         //     }
         // }
-        if self.link.unwrap_or(true) {
-            options.push(InstructionOption::NameOnly("link".to_string()));
-        }
         // parents are not supported yet: minimal version 1.7-labs
         // if self.parents.unwrap_or(false) {
-        //     options.push(InstructionOption::NameOnly("parents".to_string()));
+        //     options.push(InstructionOption::NameOnly("parents".into()));
         // }
         Ok(vec![DockerfileLine::Instruction(DockerfileInsctruction {
-            command: "COPY".to_string(),
-            content: copy_paths_to_string(&self.paths, &self.target),
+            command: "COPY".into(),
+            content: copy_paths_into(self.paths.to_vec(), &self.options.target),
             options,
         })])
     }
@@ -146,34 +154,20 @@ impl DockerfileGenerator for Copy {
 impl DockerfileGenerator for Add {
     fn generate_dockerfile_lines(
         &self,
-        _context: &GenerationContext,
+        context: &GenerationContext,
     ) -> Result<Vec<DockerfileLine>> {
         let mut options: Vec<InstructionOption> = vec![];
         if let Some(checksum) = &self.checksum {
             options.push(InstructionOption::WithValue(
-                "checksum".to_string(),
-                checksum.to_string(),
+                "checksum".into(),
+                checksum.into(),
             ));
         }
-        if let Some(chown) = &self.chown {
-            options.push(InstructionOption::WithValue(
-                "chown".to_string(),
-                chown.to_string(),
-            ));
-        }
-        if let Some(chmod) = &self.chmod {
-            options.push(InstructionOption::WithValue(
-                "chmod".to_string(),
-                chmod.to_string(),
-            ));
-        }
-        if self.link.unwrap_or(true) {
-            options.push(InstructionOption::NameOnly("link".to_string()));
-        }
+        add_copy_options(&mut options, &self.options, context);
 
         Ok(vec![DockerfileLine::Instruction(DockerfileInsctruction {
-            command: "ADD".to_string(),
-            content: copy_paths_to_string(&self.files, &self.target),
+            command: "ADD".into(),
+            content: copy_paths_into(self.files.to_vec(), &self.options.target),
             options,
         })])
     }
@@ -182,40 +176,27 @@ impl DockerfileGenerator for Add {
 impl DockerfileGenerator for AddGitRepo {
     fn generate_dockerfile_lines(
         &self,
-        _context: &GenerationContext,
+        context: &GenerationContext,
     ) -> Result<Vec<DockerfileLine>> {
         let mut options: Vec<InstructionOption> = vec![];
-        if let Some(chown) = &self.chown {
-            options.push(InstructionOption::WithValue(
-                "chown".to_string(),
-                chown.to_string(),
-            ));
-        }
-        if let Some(chmod) = &self.chmod {
-            options.push(InstructionOption::WithValue(
-                "chmod".to_string(),
-                chmod.to_string(),
-            ));
-        }
+        add_copy_options(&mut options, &self.options, context);
+
         // excludes are not supported yet: minimal version 1.7-labs
         // if let Some(exclude) = &self.exclude {
         //     for path in exclude.clone().to_vec() {
-        //         options.push(InstructionOption::WithValue("exclude".to_string(), path));
+        //         options.push(InstructionOption::WithValue("exclude".into(), path));
         //     }
         // }
         if let Some(keep_git_dir) = &self.keep_git_dir {
             options.push(InstructionOption::WithValue(
-                "keep-git-dir".to_string(),
+                "keep-git-dir".into(),
                 keep_git_dir.to_string(),
             ));
         }
-        if self.link.unwrap_or(true) {
-            options.push(InstructionOption::NameOnly("link".to_string()));
-        }
 
         Ok(vec![DockerfileLine::Instruction(DockerfileInsctruction {
-            command: "ADD".to_string(),
-            content: copy_paths_to_string(&vec![self.repo.clone()], &self.target),
+            command: "ADD".into(),
+            content: copy_paths_into(vec![self.repo.clone()], &self.options.target),
             options,
         })])
     }
@@ -224,8 +205,11 @@ impl DockerfileGenerator for AddGitRepo {
 impl Artifact {
     fn to_copy(&self) -> Copy {
         Copy {
-            paths: vec![self.source.clone()],
-            target: Some(self.target.clone()),
+            paths: vec![self.source.clone()].into(),
+            options: CopyOptions {
+                target: Some(self.target.clone()),
+                ..Default::default()
+            },
             from: Some(self.builder.clone()),
             ..Default::default()
         }
@@ -254,7 +238,7 @@ impl DockerfileGenerator for dyn Stage {
         let mut lines = vec![
             DockerfileLine::Comment(stage_name.clone()),
             DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "FROM".to_string(),
+                command: "FROM".into(),
                 content: format!(
                     "{image_name} AS {stage_name}",
                     image_name = self.from().to_string()
@@ -264,7 +248,7 @@ impl DockerfileGenerator for dyn Stage {
         ];
         if let Some(env) = self.env() {
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "ENV".to_string(),
+                command: "ENV".into(),
                 content: env
                     .into_iter()
                     .map(|(key, value)| format!("{}=\"{}\"", key, value))
@@ -275,7 +259,7 @@ impl DockerfileGenerator for dyn Stage {
         }
         if let Some(workdir) = self.workdir() {
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "WORKDIR".to_string(),
+                command: "WORKDIR".into(),
                 content: workdir.clone(),
                 options: vec![],
             }));
@@ -297,7 +281,7 @@ impl DockerfileGenerator for dyn Stage {
             };
             if let Some(instruction) = root.to_run_inscruction(&root_context)? {
                 lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                    command: "USER".to_string(),
+                    command: "USER".into(),
                     content: root_context.user.unwrap().to_string(),
                     options: vec![],
                 }));
@@ -306,7 +290,7 @@ impl DockerfileGenerator for dyn Stage {
         }
         if let Some(user) = self.user() {
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "USER".to_string(),
+                command: "USER".into(),
                 content: user.to_string(),
                 options: vec![],
             }));
@@ -342,9 +326,9 @@ impl DockerfileGenerator for Image {
         }
         lines.append(&mut <dyn Stage>::generate_dockerfile_lines(self, &context)?);
         if let Some(expose) = &self.expose {
-            expose.iter().for_each(|port| {
+            expose.to_vec().iter().for_each(|port| {
                 lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                    command: "EXPOSE".to_string(),
+                    command: "EXPOSE".into(),
                     content: port.to_string(),
                     options: vec![],
                 }))
@@ -354,45 +338,45 @@ impl DockerfileGenerator for Image {
             let mut options = vec![];
             if let Some(interval) = &healthcheck.interval {
                 options.push(InstructionOption::WithValue(
-                    "interval".to_string(),
-                    interval.to_string(),
+                    "interval".into(),
+                    interval.into(),
                 ));
             }
             if let Some(timeout) = &healthcheck.timeout {
                 options.push(InstructionOption::WithValue(
-                    "timeout".to_string(),
-                    timeout.to_string(),
+                    "timeout".into(),
+                    timeout.into(),
                 ));
             }
             if let Some(start_period) = &healthcheck.start {
                 options.push(InstructionOption::WithValue(
-                    "start-period".to_string(),
-                    start_period.to_string(),
+                    "start-period".into(),
+                    start_period.into(),
                 ));
             }
             if let Some(retries) = &healthcheck.retries {
                 options.push(InstructionOption::WithValue(
-                    "retries".to_string(),
+                    "retries".into(),
                     retries.to_string(),
                 ));
             }
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "HEALTHCHECK".to_string(),
+                command: "HEALTHCHECK".into(),
                 content: format!("CMD {}", healthcheck.cmd),
                 options,
             }))
         }
         if let Some(entrypoint) = &self.entrypoint {
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "ENTRYPOINT".to_string(),
-                content: string_vec_to_string(entrypoint),
+                command: "ENTRYPOINT".into(),
+                content: string_vec_into(entrypoint.to_vec()),
                 options: vec![],
             }))
         }
         if let Some(cmd) = &self.cmd {
             lines.push(DockerfileLine::Instruction(DockerfileInsctruction {
-                command: "CMD".to_string(),
-                content: string_vec_to_string(cmd),
+                command: "CMD".into(),
+                content: string_vec_into(cmd.to_vec()),
                 options: vec![],
             }))
         }
@@ -400,9 +384,9 @@ impl DockerfileGenerator for Image {
     }
 }
 
-fn copy_paths_to_string(paths: &Vec<String>, target: &Option<String>) -> String {
+fn copy_paths_into(paths: Vec<String>, target: &Option<String>) -> String {
     let mut parts = paths.clone();
-    parts.push(target.clone().unwrap_or("./".to_string()));
+    parts.push(target.clone().unwrap_or("./".into()));
     parts
         .iter()
         .map(|p| format!("\"{}\"", p))
@@ -410,7 +394,7 @@ fn copy_paths_to_string(paths: &Vec<String>, target: &Option<String>) -> String 
         .join(" ")
 }
 
-fn string_vec_to_string(string_vec: &Vec<String>) -> String {
+fn string_vec_into(string_vec: Vec<String>) -> String {
     format!(
         "[{}]",
         string_vec
@@ -435,7 +419,7 @@ mod test {
                 ..Default::default()
             };
             let name = builder.name(&GenerationContext {
-                previous_builders: vec!["builder-0".to_string()],
+                previous_builders: vec!["builder-0".into()],
                 ..Default::default()
             });
             assert_eq!(name, "my-builder");
@@ -445,7 +429,7 @@ mod test {
         fn name_without_name() {
             let builder = Builder::default();
             let name = builder.name(&GenerationContext {
-                previous_builders: vec!["builder-0".to_string(), "bob".to_string()],
+                previous_builders: vec!["builder-0".into(), "bob".into()],
                 ..Default::default()
             });
             assert_eq!(name, "builder-2");
@@ -454,7 +438,7 @@ mod test {
         #[test]
         fn user_with_user() {
             let builder = Builder {
-                user: Some(User::new_without_group("my-user")),
+                user: Some(PermissiveStruct::new(User::new_without_group("my-user"))),
                 ..Default::default()
             };
             let user = builder.user();
@@ -476,22 +460,24 @@ mod test {
     }
 
     mod image_name {
+        use PermissiveStruct;
+
         use super::*;
 
         #[test]
         fn test_image_name() {
             let image = Image {
-                from: Some(ImageName {
+                from: Some(PermissiveStruct::new(ImageName {
                     path: String::from("my-image"),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let name = image.name(&GenerationContext {
                 previous_builders: vec![
-                    "builder-0".to_string(),
-                    "builder-1".to_string(),
-                    "builder-2".to_string(),
+                    "builder-0".into(),
+                    "builder-1".into(),
+                    "builder-2".into(),
                 ],
                 ..Default::default()
             });
@@ -501,11 +487,11 @@ mod test {
         #[test]
         fn test_image_user_with_user() {
             let image = Image {
-                user: Some(User::new_without_group("my-user")),
-                from: Some(ImageName {
+                user: Some(PermissiveStruct::new(User::new_without_group("my-user"))),
+                from: Some(PermissiveStruct::new(ImageName {
                     path: String::from("my-image"),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let user = image.user();
@@ -521,10 +507,10 @@ mod test {
         #[test]
         fn test_image_user_without_user() {
             let image = Image {
-                from: Some(ImageName {
+                from: Some(PermissiveStruct::new(ImageName {
                     path: String::from("my-image"),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let user = image.user();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,8 @@ const FILE_HEADER_LINES: [&str; 3] = [
 /// use dofigen_lib::*;
 ///
 /// let yaml = "
-/// image: ubuntu
+/// image: 
+///   path: ubuntu
 /// ";
 /// let image: Image = from(yaml.to_string()).unwrap();
 /// assert_eq!(
@@ -61,17 +62,19 @@ const FILE_HEADER_LINES: [&str; 3] = [
 /// Basic parsing
 ///
 /// ```
-/// use dofigen_lib::{from, Image, Builder, Artifact, ImageName};
+/// use dofigen_lib::*;
 ///
 /// let yaml = r#"
 /// builders:
 ///   - name: builder
-///     from: ekidd/rust-musl-builder
+///     from: 
+///       path: ekidd/rust-musl-builder
 ///     add:
-///       - "*"
+///       - paths: ["*"]
 ///     run:
 ///       - cargo build --release
-/// from: ubuntu
+/// from:
+///   path: ubuntu
 /// artifacts:
 ///   - builder: builder
 ///     source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
@@ -83,9 +86,9 @@ const FILE_HEADER_LINES: [&str; 3] = [
 ///     Image {
 ///         builders: Some(Vec::from([Builder {
 ///             name: Some(String::from("builder")),
-///             from: "ekidd/rust-musl-builder".parse().unwrap(),
-///             copy: Some(Vec::from(["*".parse().unwrap()])),
-///             run: Some(Vec::from(["cargo build --release".parse().unwrap()])),
+///             from: ImageName { path: "ekidd/rust-musl-builder".into(), ..Default::default() },
+///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()], ..Default::default()})]),
+///             run: Some(vec!["cargo build --release".parse().unwrap()]),
 ///             ..Default::default()
 ///         }])),
 ///         from: Some(ImageName {
@@ -118,7 +121,8 @@ pub fn from(input: String) -> Result<Image> {
 /// use dofigen_lib::*;
 ///
 /// let yaml = "
-/// image: ubuntu
+/// image:
+///   path: ubuntu
 /// ";
 /// let image: Image = from_reader(yaml.as_bytes()).unwrap();
 /// assert_eq!(
@@ -141,12 +145,14 @@ pub fn from(input: String) -> Result<Image> {
 /// let yaml = r#"
 /// builders:
 ///   - name: builder
-///     from: ekidd/rust-musl-builder
+///     from:
+///       path: ekidd/rust-musl-builder
 ///     add:
-///       - "*"
+///       - paths: ["*"]
 ///     run:
 ///       - cargo build --release
-/// from: ubuntu
+/// from:
+///     path: ubuntu
 /// artifacts:
 ///   - builder: builder
 ///     source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
@@ -158,8 +164,8 @@ pub fn from(input: String) -> Result<Image> {
 ///     Image {
 ///         builders: Some(Vec::from([Builder {
 ///             name: Some(String::from("builder")),
-///             from: "ekidd/rust-musl-builder".parse().unwrap(),
-///             copy: Some(Vec::from(["*".parse().unwrap()])),
+///             from: ImageName{path: "ekidd/rust-musl-builder".into(), ..Default::default()},
+///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()], ..Default::default()})]),
 ///             run: Some(Vec::from(["cargo build --release".parse().unwrap()])),
 ///             ..Default::default()
 ///         }])),
@@ -317,6 +323,8 @@ pub fn generate_json_schema() -> String {
     serde_json::to_string_pretty(&schema).unwrap()
 }
 
+
+#[cfg(feature = "permissive")]
 #[cfg(test)]
 mod test {
     use super::*;
@@ -432,7 +440,7 @@ artifacts:
                         path: String::from("ekidd/rust-musl-builder"),
                         ..Default::default()
                     },
-                    copy: Some(vec![CopyResources::Copy(Copy {
+                    copy: Some(vec![CopyResource::Copy(Copy {
                         paths: vec![String::from("*")],
                         ..Default::default()
                     })]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,17 +43,17 @@ const FILE_HEADER_LINES: [&str; 3] = [
 /// use dofigen_lib::*;
 ///
 /// let yaml = "
-/// image: 
+/// image:
 ///   path: ubuntu
 /// ";
-/// let image: Image = from(yaml.to_string()).unwrap();
+/// let image: Image = from(yaml.into()).unwrap();
 /// assert_eq!(
 ///     image,
 ///     Image {
 ///         from: Some(ImageName {
 ///             path: String::from("ubuntu"),
 ///             ..Default::default()
-///         }),
+///         }.into()),
 ///         ..Default::default()
 ///     }
 /// );
@@ -67,7 +67,7 @@ const FILE_HEADER_LINES: [&str; 3] = [
 /// let yaml = r#"
 /// builders:
 ///   - name: builder
-///     from: 
+///     from:
 ///       path: ekidd/rust-musl-builder
 ///     add:
 ///       - paths: ["*"]
@@ -80,21 +80,21 @@ const FILE_HEADER_LINES: [&str; 3] = [
 ///     source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
 ///     target: /app
 /// "#;
-/// let image: Image = from(yaml.to_string()).unwrap();
+/// let image: Image = from(yaml.into()).unwrap();
 /// assert_eq!(
 ///     image,
 ///     Image {
 ///         builders: Some(Vec::from([Builder {
 ///             name: Some(String::from("builder")),
-///             from: ImageName { path: "ekidd/rust-musl-builder".into(), ..Default::default() },
-///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()], ..Default::default()})]),
-///             run: Some(vec!["cargo build --release".parse().unwrap()]),
+///             from: ImageName { path: "ekidd/rust-musl-builder".into(), ..Default::default() }.into(),
+///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()].into(), ..Default::default()}).into()].into()),
+///             run: Some(vec!["cargo build --release".parse().unwrap()].into()),
 ///             ..Default::default()
 ///         }])),
 ///         from: Some(ImageName {
 ///             path: "ubuntu".parse().unwrap(),
 ///             ..Default::default()
-///         }),
+///         }.into()),
 ///         artifacts: Some(Vec::from([Artifact {
 ///             builder: String::from("builder"),
 ///             source: String::from(
@@ -131,7 +131,7 @@ pub fn from(input: String) -> Result<Image> {
 ///         from: Some(ImageName {
 ///             path: String::from("ubuntu"),
 ///             ..Default::default()
-///         }),
+///         }.into()),
 ///         ..Default::default()
 ///     }
 /// );
@@ -164,15 +164,15 @@ pub fn from(input: String) -> Result<Image> {
 ///     Image {
 ///         builders: Some(Vec::from([Builder {
 ///             name: Some(String::from("builder")),
-///             from: ImageName{path: "ekidd/rust-musl-builder".into(), ..Default::default()},
-///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()], ..Default::default()})]),
-///             run: Some(Vec::from(["cargo build --release".parse().unwrap()])),
+///             from: ImageName{path: "ekidd/rust-musl-builder".into(), ..Default::default()}.into(),
+///             copy: Some(vec![CopyResource::Copy(Copy{paths: vec!["*".into()].into(), ..Default::default()}).into()].into()),
+///             run: Some(vec!["cargo build --release".parse().unwrap()].into()),
 ///             ..Default::default()
 ///         }])),
 ///         from: Some(ImageName {
 ///             path: String::from("ubuntu"),
 ///             ..Default::default()
-///         }),
+///         }.into()),
 ///         artifacts: Some(Vec::from([Artifact {
 ///             builder: String::from("builder"),
 ///             source: String::from(
@@ -218,7 +218,7 @@ pub fn from_file_path(path: &std::path::PathBuf) -> Result<Image> {
 ///     from: Some(ImageName {
 ///         path: String::from("ubuntu"),
 ///         ..Default::default()
-///     }),
+///     }.into()),
 ///     ..Default::default()
 /// };
 /// let dockerfile: String = generate_dockerfile(&image).unwrap();
@@ -250,7 +250,7 @@ pub fn generate_dockerfile(image: &Image) -> Result<String> {
 /// use dofigen_lib::{generate_dockerignore, Image};
 ///
 /// let image = Image {
-///     context: Some(Vec::from([String::from("/src")])),
+///     context: Some(vec![String::from("/src")].into()),
 ///     ..Default::default()
 /// };
 /// let dockerfile: String = generate_dockerignore(&image);
@@ -266,7 +266,7 @@ pub fn generate_dockerfile(image: &Image) -> Result<String> {
 /// use dofigen_lib::{generate_dockerignore, Image};
 ///
 /// let image = Image {
-///     ignore: Some(Vec::from([String::from("target")])),
+///     ignore: Some(vec![String::from("target")].into()),
 ///     ..Default::default()
 /// };
 /// let dockerfile: String = generate_dockerignore(&image);
@@ -282,8 +282,8 @@ pub fn generate_dockerfile(image: &Image) -> Result<String> {
 /// use dofigen_lib::{generate_dockerignore, Image};
 ///
 /// let image = Image {
-///     context: Some(Vec::from([String::from("/src")])),
-///     ignore: Some(Vec::from([String::from("/src/*.test.rs")])),
+///     context: Some(vec![String::from("/src")].into()),
+///     ignore: Some(vec![String::from("/src/*.test.rs")].into()),
 ///     ..Default::default()
 /// };
 /// let dockerfile: String = generate_dockerignore(&image);
@@ -322,7 +322,6 @@ pub fn generate_json_schema() -> String {
     let schema = schema_for!(Image);
     serde_json::to_string_pretty(&schema).unwrap()
 }
-
 
 #[cfg(feature = "permissive")]
 #[cfg(test)]
@@ -363,7 +362,7 @@ mod test {
         - test
         "#;
 
-        let image: Image = from(yaml.to_string()).map_err(Error::from).unwrap();
+        let image: Image = from(yaml.into()).map_err(Error::from).unwrap();
         let dockerfile: String = generate_dockerfile(&image).unwrap();
 
         assert_eq!(
@@ -430,21 +429,25 @@ artifacts:
   source: /home/rust/src/target/x86_64-unknown-linux-musl/release/template-rust
   destination: /app
 "#;
-        let image: Image = from(yaml.to_string()).unwrap();
+        let image: Image = from(yaml.into()).unwrap();
         assert_eq!(
             image,
             Image {
                 builders: Some(vec![Builder {
                     name: Some(String::from("builder")),
-                    from: ImageName {
+                    from: PermissiveStruct::new(ImageName {
                         path: String::from("ekidd/rust-musl-builder"),
                         ..Default::default()
-                    },
-                    copy: Some(vec![CopyResource::Copy(Copy {
-                        paths: vec![String::from("*")],
-                        ..Default::default()
-                    })]),
-                    run: Some(vec![String::from("cargo build --release")]),
+                    }),
+                    copy: Some(PermissiveVec::new(vec![PermissiveStruct::new(
+                        CopyResource::Copy(Copy {
+                            paths: vec![String::from("*")].into(),
+                            ..Default::default()
+                        })
+                    )])),
+                    run: Some(PermissiveVec::new(vec![String::from(
+                        "cargo build --release"
+                    )])),
                     ..Default::default()
                 }]),
                 artifacts: Some(Vec::from([Artifact {
@@ -470,7 +473,7 @@ run:
       echo "Test"
     fi
 "#;
-        let image: Image = from(yaml.to_string()).unwrap();
+        let image: Image = from(yaml.into()).unwrap();
         let dockerfile: String = generate_dockerfile(&image).unwrap();
 
         assert_eq!(
@@ -497,7 +500,7 @@ RUN \
 image: scratch
 from: alpine
 "#;
-        let result = from(yaml.to_string());
+        let result = from(yaml.into());
         assert!(
             result.is_err(),
             "The parsing must fail since from and image are not compatible"
@@ -510,7 +513,7 @@ from: alpine
 from: alpine
 test: Fake value
 "#;
-        let result = from(yaml.to_string());
+        let result = from(yaml.into());
         assert!(
             result.is_err(),
             "The parsing must fail since 'test' is not a valid field"
@@ -558,7 +561,7 @@ ignore:
 - test
 "#;
 
-        from(yaml.to_string())?;
+        from(yaml.into())?;
         Ok(())
     }
 
@@ -581,7 +584,7 @@ ignore:
         cache: /tmp
         "#;
 
-        let image: Image = from(yaml.to_string()).unwrap();
+        let image: Image = from(yaml.into()).unwrap();
         let dockerfile: String = generate_dockerfile(&image).unwrap();
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@
 mod dockerfile_struct;
 mod dofigen_struct;
 mod errors;
+#[cfg(feature = "permissive")]
 mod from_str;
 mod generator;
 mod script_runner;
+#[cfg(feature = "permissive")]
 mod serde_permissive;
 mod stage;
 use dockerfile_struct::{DockerfileContent, DockerfileLine};

--- a/src/serde_permissive.rs
+++ b/src/serde_permissive.rs
@@ -22,17 +22,6 @@ where
     Struct(T),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
-#[serde(untagged)]
-pub enum StringOrStruct<T>
-where
-    T: FromStr<Err = Error>,
-{
-    String(String),
-    Struct(T),
-}
-
 pub fn deserialize_optional_one_or_many<'de, D, T>(
     deserializer: D,
 ) -> Result<Option<Vec<T>>, D::Error>

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -4,7 +4,7 @@ use crate::{
     dofigen_struct::{Builder, Image},
     generator::GenerationContext,
     script_runner::ScriptRunner,
-    Artifact, CopyResources, ImageName, Root, User,
+    Artifact, CopyResource, ImageName, Root, User,
 };
 
 pub trait BaseStage: ScriptRunner {
@@ -15,7 +15,7 @@ pub trait BaseStage: ScriptRunner {
 pub trait Stage: BaseStage {
     fn workdir(&self) -> Option<&String>;
     fn env(&self) -> Option<&HashMap<String, String>>;
-    fn copy(&self) -> Option<&Vec<CopyResources>>;
+    fn copy(&self) -> Option<&Vec<CopyResource>>;
     fn artifacts(&self) -> Option<&Vec<Artifact>>;
     fn root(&self) -> Option<&Root>;
 }
@@ -66,7 +66,7 @@ macro_rules! impl_Stage {
                 self.env.as_ref()
             }
 
-            fn copy(&self) -> Option<&Vec<CopyResources>> {
+            fn copy(&self) -> Option<&Vec<CopyResource>> {
                 self.copy.as_ref()
             }
 

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 
 use crate::{
     dofigen_struct::{Builder, Image},
     generator::GenerationContext,
     script_runner::ScriptRunner,
-    Artifact, CopyResource, ImageName, Root, User,
+    Artifact, CopyResource, ImageName, PermissiveStruct, Root, User,
 };
 
 pub trait BaseStage: ScriptRunner {
@@ -15,7 +15,7 @@ pub trait BaseStage: ScriptRunner {
 pub trait Stage: BaseStage {
     fn workdir(&self) -> Option<&String>;
     fn env(&self) -> Option<&HashMap<String, String>>;
-    fn copy(&self) -> Option<&Vec<CopyResource>>;
+    fn copy(&self) -> Option<&Vec<PermissiveStruct<CopyResource>>>;
     fn artifacts(&self) -> Option<&Vec<Artifact>>;
     fn root(&self) -> Option<&Root>;
 }
@@ -28,11 +28,11 @@ impl BaseStage for Builder {
         }
     }
     fn from(&self) -> ImageName {
-        self.from.clone()
+        self.from.deref().clone()
     }
 
     fn user(&self) -> Option<User> {
-        self.user.clone()
+        self.user.clone().map(|user| user.deref().clone())
     }
 }
 
@@ -42,7 +42,7 @@ impl BaseStage for Image {
     }
     fn from(&self) -> ImageName {
         if let Some(image_name) = &self.from {
-            image_name.clone()
+            image_name.deref().clone()
         } else {
             ImageName {
                 path: String::from("scratch"),
@@ -51,7 +51,10 @@ impl BaseStage for Image {
         }
     }
     fn user(&self) -> Option<User> {
-        self.user.clone().or(Some(User::new("1000")))
+        self.user
+            .clone()
+            .map(|user| user.deref().clone())
+            .or(Some(User::new("1000")))
     }
 }
 
@@ -66,8 +69,8 @@ macro_rules! impl_Stage {
                 self.env.as_ref()
             }
 
-            fn copy(&self) -> Option<&Vec<CopyResource>> {
-                self.copy.as_ref()
+            fn copy(&self) -> Option<&Vec<PermissiveStruct<CopyResource>>> {
+                self.copy.as_ref().map(|vec|vec.deref())
             }
 
             fn artifacts(&self) -> Option<&Vec<Artifact>> {
@@ -95,7 +98,7 @@ impl User {
             .flatten()
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn into(&self) -> String {
         match &self.group {
             Some(group) => format!("{}:{}", self.user, group),
             None => self.user.clone(),
@@ -121,7 +124,7 @@ impl User {
 
 #[cfg(test)]
 mod tests {
-    use crate::ImageName;
+    use crate::{ImageName, PermissiveStruct};
 
     use super::*;
 
@@ -132,7 +135,7 @@ mod tests {
             ..Default::default()
         };
         let name = builder.name(&GenerationContext {
-            previous_builders: vec!["builder-0".to_string()],
+            previous_builders: vec!["builder-0".into()],
             ..Default::default()
         });
         assert_eq!(name, "my-builder");
@@ -142,7 +145,7 @@ mod tests {
     fn test_builder_name_without_name() {
         let builder = Builder::default();
         let name = builder.name(&GenerationContext {
-            previous_builders: vec!["builder-0".to_string(), "bob".to_string()],
+            previous_builders: vec!["builder-0".into(), "bob".into()],
             ..Default::default()
         });
         assert_eq!(name, "builder-2");
@@ -151,10 +154,10 @@ mod tests {
     #[test]
     fn test_builder_user_with_user() {
         let builder = Builder {
-            user: Some(User {
+            user: Some(PermissiveStruct::new(User {
                 user: "my-user".into(),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         let user = builder.user();
@@ -177,17 +180,17 @@ mod tests {
     #[test]
     fn test_image_name() {
         let image = Image {
-            from: Some(ImageName {
+            from: Some(PermissiveStruct::new(ImageName {
                 path: String::from("my-image"),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         let name = image.name(&GenerationContext {
             previous_builders: vec![
-                "builder-0".to_string(),
-                "bob".to_string(),
-                "john".to_string(),
+                "builder-0".into(),
+                "bob".into(),
+                "john".into(),
             ],
             ..Default::default()
         });
@@ -197,14 +200,14 @@ mod tests {
     #[test]
     fn test_image_user_with_user() {
         let image = Image {
-            user: Some(User {
+            user: Some(PermissiveStruct::new(User {
                 user: "my-user".into(),
                 ..Default::default()
-            }),
-            from: Some(ImageName {
+            })),
+            from: Some(PermissiveStruct::new(ImageName {
                 path: String::from("my-image"),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         let user = image.user();
@@ -220,10 +223,10 @@ mod tests {
     #[test]
     fn test_image_user_without_user() {
         let image = Image {
-            from: Some(ImageName {
+            from: Some(PermissiveStruct::new(ImageName {
                 path: String::from("my-image"),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         let user = image.user();

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -187,11 +187,7 @@ mod tests {
             ..Default::default()
         };
         let name = image.name(&GenerationContext {
-            previous_builders: vec![
-                "builder-0".into(),
-                "bob".into(),
-                "john".into(),
-            ],
+            previous_builders: vec!["builder-0".into(), "bob".into(), "john".into()],
             ..Default::default()
         });
         assert_eq!(name, "runtime");


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
The permissive structure makes the generated binaries 2x larger.

In order to let the user choose if he wants to use it or not, the serde_permissive module have been refactored and made as a feature: `permissive`.

## Technical highlight/advice

The feature is not a default feature, so the feature is added to the CLI generation in the doc and the CI.

The unit tests do not behave the with and without this feature since the resulting struct is not the same. The CI unit tests are now launched with and without this feature.

## How to test my changes

To test the changes we can try to parse a Dofigen permissive structure with and without the feature:

```bash
# Fails without the permissive feature
echo "from: ubuntu" | cargo run -F cli -- gen -f - -o -
# Displays the Dockerfile
echo "from: ubuntu" | cargo run -F cli -F permissive -- gen -f - -o -
```

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [x] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


