### PR TITLE
fix: Custom Docker repos management and remove 'library' on Docker Hub

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -243,7 +243,7 @@ impl DofigenContext {
                 tag = tag
             );
             let response = client.get(&request_url).send().map_err(Error::from)?;
-            
+
             response.json().map_err(Error::from)?
         } else {
             let request_url = format!(


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR

Fix Docker digest management for both Docker Hub and other repos.

## Technical highlight/advice

For now, we user the Docker Hub API instead of the Docker v2 API for Docker Hub since the API needs authentication.
Maybe using the docker authentication in the docker deamon could be a better solution for later.

## How to test my changes

Here are two Dofigen files to reproduce both problems.

### Docker Hub

```yaml
fromImage: php:8
```

Run `dofigen gen` twice and you'll see that the second run will try to remove and add the php image. (with and without `library/`).

### Other repos

```yaml
fromImage: quay.io/nginx/nginx-ingress
```

The `dofigen gen` command won't be able to load the image digest.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


