### PR TITLE
ci: install a recent protoc in the cross build containers

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,17 @@
 # `cross` is used in CI to (cross-)compile the release binaries.
 #
 # The `dofigen-frontend` binary depends on `buildkit-proto`, whose build script
-# invokes `protoc` to compile the Buildkit `.proto` files. The default `cross`
-# images don't ship `protoc`, so we install it in every build container.
-# `protoc` runs on the build host architecture (it only generates Rust code), so
-# the host package is enough for all targets.
+# invokes `protoc` to compile the Buildkit `.proto` files. The `protoc` provided
+# by the default `cross` images (via the distro package) is too old to parse the
+# vendored protobuf definitions, so we download a recent release into every build
+# container, under `/usr/local` (which precedes `/usr/bin` on `PATH`, so it
+# shadows any preexisting `protoc`). `protoc` runs on the build host architecture
+# (it only generates Rust code), so the x86_64 host binary is enough for all
+# targets.
 [build]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes protobuf-compiler",
+    "apt-get update && apt-get install --assume-yes curl unzip",
+    "curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-linux-x86_64.zip",
+    "unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'",
+    "chmod +x /usr/local/bin/protoc",
 ]


### PR DESCRIPTION
## About this PR

Stacked on top of #475 (`buildkit-frontend`). Fixes the failing **Build linux** release jobs.

### Problem

`dofigen-frontend` depends on `buildkit-proto`, whose build script runs `protoc` over Buildkit's vendored `.proto` files. The `protoc` shipped in the `cross` build containers (via the distro package) is too old to parse those definitions, so the release build fails with `protoc failed: google/protobuf/descriptor.proto: Expected ";"` — while the native `test-frontend` job passes because the runner's distro `protoc` (3.21) is new enough.

### Fix

Keep building with `cross`, but download a pinned recent `protoc` release into each build container (under `/usr/local`, which shadows the outdated one on `PATH`) instead of relying on the distro package.

- `Cross.toml`: replace `apt-get install protobuf-compiler` with a pinned `protoc` release download.

https://claude.ai/code/session_01DocCJCXtEmaMdwiqXeHvnv